### PR TITLE
feat: Mail-Vorlagen überarbeiten – Rich-Editor, Empfänger, neue Varia…

### DIFF
--- a/backend/src/db.cpp
+++ b/backend/src/db.cpp
@@ -403,14 +403,14 @@ std::optional<Activity> Database::create_activity(const ActivityInput &input)
                 mat_json.c_str(), needs_s,
                 input.siko_base64->c_str()};
             PGresult *r = PQexecParams(conn_,
-                "INSERT INTO activities "
-                "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, siko) "
-                "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
-                "$8::department_enum, $9::jsonb, $10, decode($11, 'base64')) "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                11, nullptr, p2, nullptr, nullptr, 0);
+                                       "INSERT INTO activities "
+                                       "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, siko) "
+                                       "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "$8::department_enum, $9::jsonb, $10, decode($11, 'base64')) "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       11, nullptr, p2, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -432,14 +432,14 @@ std::optional<Activity> Database::create_activity(const ActivityInput &input)
                 mat_json.c_str(), needs_s,
                 bwi_str.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "INSERT INTO activities "
-                "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, bad_weather_info) "
-                "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
-                "$8::department_enum, $9::jsonb, $10, $11) "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                11, nullptr, p, nullptr, nullptr, 0);
+                                       "INSERT INTO activities "
+                                       "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, bad_weather_info) "
+                                       "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "$8::department_enum, $9::jsonb, $10, $11) "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       11, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -495,16 +495,16 @@ std::optional<Activity> Database::update_activity(const std::string &id, const A
                 input.siko_base64->c_str(),
                 bwi_str.c_str(), id.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "UPDATE activities SET "
-                "title=$1, date=$2::date, start_time=$3, end_time=$4, "
-                "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
-                "department=$8::department_enum, material=$9::jsonb, "
-                "needs_siko=$10, siko=decode($11, 'base64'), bad_weather_info=$12 "
-                "WHERE id=$13 "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                13, nullptr, p, nullptr, nullptr, 0);
+                                       "UPDATE activities SET "
+                                       "title=$1, date=$2::date, start_time=$3, end_time=$4, "
+                                       "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "department=$8::department_enum, material=$9::jsonb, "
+                                       "needs_siko=$10, siko=decode($11, 'base64'), bad_weather_info=$12 "
+                                       "WHERE id=$13 "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       13, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -528,16 +528,16 @@ std::optional<Activity> Database::update_activity(const std::string &id, const A
                 mat_json.c_str(), needs_s,
                 bwi_str.c_str(), id.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "UPDATE activities SET "
-                "title=$1, date=$2::date, start_time=$3, end_time=$4, "
-                "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
-                "department=$8::department_enum, material=$9::jsonb, "
-                "needs_siko=$10, siko=NULL, bad_weather_info=$11 "
-                "WHERE id=$12 "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                12, nullptr, p, nullptr, nullptr, 0);
+                                       "UPDATE activities SET "
+                                       "title=$1, date=$2::date, start_time=$3, end_time=$4, "
+                                       "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "department=$8::department_enum, material=$9::jsonb, "
+                                       "needs_siko=$10, siko=NULL, bad_weather_info=$11 "
+                                       "WHERE id=$12 "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       12, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -562,16 +562,16 @@ std::optional<Activity> Database::update_activity(const std::string &id, const A
                 mat_json.c_str(), needs_s,
                 bwi_str.c_str(), id.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "UPDATE activities SET "
-                "title=$1, date=$2::date, start_time=$3, end_time=$4, "
-                "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
-                "department=$8::department_enum, material=$9::jsonb, "
-                "needs_siko=$10, bad_weather_info=$11 "
-                "WHERE id=$12 "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                12, nullptr, p, nullptr, nullptr, 0);
+                                       "UPDATE activities SET "
+                                       "title=$1, date=$2::date, start_time=$3, end_time=$4, "
+                                       "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "department=$8::department_enum, material=$9::jsonb, "
+                                       "needs_siko=$10, bad_weather_info=$11 "
+                                       "WHERE id=$12 "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       12, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -681,7 +681,8 @@ std::optional<UserRecord> Database::upsert_user(const std::string &oid,
     {
         on_conflict =
             "ON CONFLICT (microsoft_oid) DO UPDATE "
-            "SET email = EXCLUDED.email, role = '" + initial_role + "'::user_role, updated_at = NOW() ";
+            "SET email = EXCLUDED.email, role = '" +
+            initial_role + "'::user_role, updated_at = NOW() ";
     }
     else
     {
@@ -692,7 +693,8 @@ std::optional<UserRecord> Database::upsert_user(const std::string &oid,
 
     std::string sql =
         "INSERT INTO users (microsoft_oid, email, display_name, department, role) "
-        "VALUES ($1, $2, $3, '" + initial_dept + "'::department_enum, '" + initial_role + "'::user_role) " +
+        "VALUES ($1, $2, $3, '" +
+        initial_dept + "'::department_enum, '" + initial_role + "'::user_role) " +
         on_conflict +
         "RETURNING id, microsoft_oid, email, display_name, department::text, role::text, created_at, updated_at";
 
@@ -782,9 +784,9 @@ std::optional<UserRecord> Database::update_user(const std::string &oid,
 // ---- update_user_admin ------------------------------------------------------
 
 std::optional<UserRecord> Database::update_user_admin(const std::string &id,
-                                                       const std::string &display_name,
-                                                       const std::optional<std::string> &department,
-                                                       const std::string &role)
+                                                      const std::string &display_name,
+                                                      const std::optional<std::string> &department,
+                                                      const std::string &role)
 {
     ensure_connected();
     std::string dept_str = department ? *department : "";
@@ -825,6 +827,8 @@ MailTemplate Database::row_to_mail_template(PGresult *res, int row)
     t.department = col("department") ? col("department") : "";
     t.subject = col("subject") ? col("subject") : "";
     t.body = col("body") ? col("body") : "";
+    if (col("recipients"))
+        t.recipients = parse_pg_array(col("recipients"));
     t.created_at = col("created_at") ? col("created_at") : "";
     t.updated_at = col("updated_at") ? col("updated_at") : "";
     return t;
@@ -834,7 +838,7 @@ std::vector<MailTemplate> Database::list_mail_templates()
 {
     ensure_connected();
     PGresult *res = PQexec(conn_,
-                           "SELECT id, department::text, subject, body, created_at, updated_at "
+                           "SELECT id, department::text, subject, body, recipients, created_at, updated_at "
                            "FROM mail_templates ORDER BY department");
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -857,7 +861,7 @@ std::optional<MailTemplate> Database::get_mail_template_by_department(const std:
     ensure_connected();
     const char *params[1] = {department.c_str()};
     PGresult *res = PQexecParams(conn_,
-                                 "SELECT id, department::text, subject, body, created_at, updated_at "
+                                 "SELECT id, department::text, subject, body, recipients, created_at, updated_at "
                                  "FROM mail_templates WHERE department = $1::department_enum",
                                  1, nullptr, params, nullptr, nullptr, 0);
 
@@ -873,16 +877,26 @@ std::optional<MailTemplate> Database::get_mail_template_by_department(const std:
 
 std::optional<MailTemplate> Database::upsert_mail_template(const std::string &department,
                                                            const std::string &subject,
-                                                           const std::string &body)
+                                                           const std::string &body,
+                                                           const std::vector<std::string> &recipients)
 {
     ensure_connected();
-    const char *params[3] = {department.c_str(), subject.c_str(), body.c_str()};
+    // Build PostgreSQL text array literal for recipients
+    std::string recipients_arr = "{";
+    for (size_t i = 0; i < recipients.size(); ++i)
+    {
+        if (i > 0)
+            recipients_arr += ",";
+        recipients_arr += "\"" + recipients[i] + "\"";
+    }
+    recipients_arr += "}";
+    const char *params[4] = {department.c_str(), subject.c_str(), body.c_str(), recipients_arr.c_str()};
     PGresult *res = PQexecParams(conn_,
-                                 "INSERT INTO mail_templates (department, subject, body) "
-                                 "VALUES ($1::department_enum, $2, $3) "
-                                 "ON CONFLICT (department) DO UPDATE SET subject = EXCLUDED.subject, body = EXCLUDED.body "
-                                 "RETURNING id, department::text, subject, body, created_at, updated_at",
-                                 3, nullptr, params, nullptr, nullptr, 0);
+                                 "INSERT INTO mail_templates (department, subject, body, recipients) "
+                                 "VALUES ($1::department_enum, $2, $3, $4::text[]) "
+                                 "ON CONFLICT (department) DO UPDATE SET subject = EXCLUDED.subject, body = EXCLUDED.body, recipients = EXCLUDED.recipients "
+                                 "RETURNING id, department::text, subject, body, recipients, created_at, updated_at",
+                                 4, nullptr, params, nullptr, nullptr, 0);
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK || PQntuples(res) == 0)
     {

--- a/backend/src/db.hpp
+++ b/backend/src/db.hpp
@@ -23,6 +23,7 @@ struct MailTemplate
     std::string department;
     std::string subject;
     std::string body;
+    std::vector<std::string> recipients;
     std::string created_at;
     std::string updated_at;
 };
@@ -73,7 +74,8 @@ public:
     std::optional<MailTemplate> get_mail_template_by_department(const std::string &department);
     std::optional<MailTemplate> upsert_mail_template(const std::string &department,
                                                      const std::string &subject,
-                                                     const std::string &body);
+                                                     const std::string &body,
+                                                     const std::vector<std::string> &recipients);
 
     // Send mail via Microsoft Graph
     bool send_mail(const std::string &access_token,

--- a/backend/src/handlers.cpp
+++ b/backend/src/handlers.cpp
@@ -932,6 +932,7 @@ static nlohmann::json template_to_json(const MailTemplate &t)
         {"department", t.department},
         {"subject", t.subject},
         {"body", t.body},
+        {"recipients", t.recipients},
         {"created_at", t.created_at},
         {"updated_at", t.updated_at}};
 }
@@ -1036,8 +1037,16 @@ void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db)
         std::string subject = j.value("subject", "");
         std::string body    = j.value("body", "");
 
+        std::vector<std::string> recipients;
+        if (j.contains("recipients") && j["recipients"].is_array()) {
+            for (auto& e : j["recipients"]) {
+                if (e.is_string() && !e.get<std::string>().empty())
+                    recipients.push_back(e.get<std::string>());
+            }
+        }
+
         try {
-            auto tpl = db.upsert_mail_template(department, subject, body);
+            auto tpl = db.upsert_mail_template(department, subject, body, recipients);
             if (!tpl) {
                 send_json(res, 500, R"({"error":"db error"})");
                 return;

--- a/db/init.sql
+++ b/db/init.sql
@@ -73,6 +73,7 @@ CREATE TABLE mail_templates (
     department  department_enum NOT NULL UNIQUE,
     subject     TEXT            NOT NULL DEFAULT '',
     body        TEXT            NOT NULL DEFAULT '',
+    recipients  TEXT[]          NOT NULL DEFAULT '{}',
     created_at  TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
     updated_at  TIMESTAMPTZ     NOT NULL DEFAULT NOW()
 );
@@ -82,9 +83,9 @@ CREATE TRIGGER trg_mail_templates_updated_at
     FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
 
 -- Seed default (empty) templates for every department
-INSERT INTO mail_templates (department, subject, body) VALUES
-    ('Leiter', '', ''),
-    ('Pio',    '', ''),
-    ('Pfadi',  '', ''),
-    ('Wölfe',  '', ''),
-    ('Biber',  '', '');
+INSERT INTO mail_templates (department, subject, body, recipients) VALUES
+    ('Leiter', '', '', '{}'),
+    ('Pio',    '', '', '{}'),
+    ('Pfadi',  '', '', '{}'),
+    ('Wölfe',  '', '', '{}'),
+    ('Biber',  '', '', '{}');

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -120,10 +120,12 @@ INSERT INTO programs (activity_id, time, title, description, responsible) VALUES
 -- Mail-Templates mit Beispielinhalt
 UPDATE mail_templates SET
     subject = 'Einladung zur Pfadi-Aktivität: {{titel}}',
-    body = 'Liebe Eltern\n\nWir laden herzlich zur nächsten Aktivität ein:\n\n📅 Datum: {{datum}}\n🕐 Zeit: {{startzeit}} – {{endzeit}}\n📍 Ort: {{ort}}\n\nZiel: {{ziel}}\n\nBei Schlechtwetter: {{schlechtwetter}}\n\nFreundliche Grüsse\nDie Pfadileitung'
+    body = '<p>Liebe Eltern</p><p>Wir laden herzlich zur nächsten Aktivität ein:</p><p>📅 Datum: {{datum}}<br>🕐 Zeit: {{startzeit}} – {{endzeit}}<br>📍 Ort: {{ort}}</p><p>Ziel: {{ziel}}</p><p>Bei Schlechtwetter: {{schlechtwetter}}</p><p>Freundliche Grüsse<br>{{absender_name}}<br>{{absender_email}}</p>',
+    recipients = ARRAY['eltern-pfadi@pfadihue.ch']
 WHERE department = 'Pfadi';
 
 UPDATE mail_templates SET
     subject = 'Wölfe-Aktivität: {{titel}}',
-    body = 'Liebe Eltern\n\nDie nächste Wölfe-Aktivität steht an:\n\n📅 {{datum}}\n🕐 {{startzeit}} – {{endzeit}}\n📍 {{ort}}\n\nMitbringen: wetterfeste Kleidung, Zvieri\n\nBis bald!\nDas Wölfe-Team'
+    body = '<p>Liebe Eltern</p><p>Die nächste Wölfe-Aktivität steht an:</p><p>📅 {{datum_kurz}}<br>🕐 {{startzeit}} – {{endzeit}}<br>📍 {{ort}}</p><p>Mitbringen: wetterfeste Kleidung, Zvieri</p><p>Bis bald!<br>Das Wölfe-Team<br>{{absender_name}}</p>',
+    recipients = ARRAY['eltern-woelfe@pfadihue.ch']
 WHERE department = 'Wölfe';

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1457,3 +1457,188 @@ body {
 	font-size: 0.82rem;
 	color: #6b7280;
 }
+
+/* =============================================================================
+   RICH TEXT EDITOR — contenteditable with toolbar
+   ============================================================================= */
+
+.rich-editor-toolbar {
+	display: flex;
+	gap: 2px;
+	padding: 6px 8px;
+	background: #f9fafb;
+	border: 1px solid #d1d5db;
+	border-bottom: none;
+	border-radius: 8px 8px 0 0;
+	flex-wrap: wrap;
+}
+
+.rich-editor-toolbar button {
+	padding: 4px 10px;
+	font-size: 0.82rem;
+	font-family: inherit;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	color: #374151;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+	line-height: 1.4;
+}
+
+.rich-editor-toolbar button:hover {
+	background: #e8f0fe;
+	border-color: #0080ff;
+}
+
+.rich-editor-toolbar button.toolbar-btn--active,
+.toolbar-btn-sm.toolbar-btn--active {
+	background: #dbeafe;
+	border-color: #0080ff;
+	color: #0080ff;
+}
+
+.toolbar-select {
+	padding: 4px 8px;
+	font-size: 0.82rem;
+	font-family: inherit;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	color: #374151;
+	line-height: 1.4;
+	outline: none;
+	max-width: 140px;
+}
+
+.toolbar-select--narrow {
+	max-width: 64px;
+	text-align: center;
+}
+
+.toolbar-btn-sm {
+	padding: 4px 7px;
+	font-size: 0.78rem;
+	font-family: inherit;
+	font-weight: 700;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	color: #374151;
+	line-height: 1.4;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+}
+
+.toolbar-btn-sm:hover {
+	background: #e8f0fe;
+	border-color: #0080ff;
+}
+
+.toolbar-select:focus {
+	border-color: #0080ff;
+}
+
+.toolbar-color {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 2px 6px;
+	font-size: 0.82rem;
+	font-weight: 700;
+	color: #374151;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+	line-height: 1.4;
+}
+
+.toolbar-color:hover {
+	background: #e8f0fe;
+	border-color: #0080ff;
+}
+
+.toolbar-color input[type='color'] {
+	width: 18px;
+	height: 18px;
+	padding: 0;
+	border: none;
+	background: none;
+	cursor: pointer;
+}
+
+.toolbar-color--bg {
+	background: #fffde7;
+}
+
+.toolbar-color-icon {
+	background: #ffe066;
+	padding: 0 3px;
+	border-radius: 2px;
+}
+
+.toolbar-sep {
+	width: 1px;
+	background: #e5e7eb;
+	margin: 2px 4px;
+	align-self: stretch;
+}
+
+.rich-editor {
+	min-height: 220px;
+	max-height: 500px;
+	overflow-y: auto;
+	padding: 12px 14px;
+	font-size: 1rem;
+	font-family: inherit;
+	line-height: 1.6;
+	border: 1px solid #d1d5db;
+	border-radius: 0 0 8px 8px;
+	background: #fff;
+	outline: none;
+	transition:
+		border-color 0.15s,
+		box-shadow 0.15s;
+}
+
+.rich-editor:focus {
+	border-color: #0080ff;
+	box-shadow: 0 0 0 3px rgba(0, 128, 255, 0.15);
+}
+
+.rich-editor:empty::before {
+	content: attr(data-placeholder);
+	color: #9ca3af;
+	pointer-events: none;
+}
+
+.rich-editor ul,
+.rich-editor ol {
+	padding-left: 24px;
+	margin: 4px 0;
+}
+
+.rich-editor p {
+	margin: 0 0 4px;
+}
+
+@media (max-width: 599px) {
+	.rich-editor {
+		min-height: 180px;
+		font-size: 1rem;
+	}
+
+	.rich-editor-toolbar button {
+		padding: 6px 10px;
+		min-height: 36px;
+	}
+}

--- a/frontend/src/components/UserAvatar.vue
+++ b/frontend/src/components/UserAvatar.vue
@@ -25,13 +25,6 @@
 				>
 					Profil bearbeiten
 				</router-link>
-				<router-link
-					class="avatar-dropdown-item"
-					to="/mail-templates"
-					@click="open = false"
-				>
-					Mail-Vorlagen
-				</router-link>
 				<button
 					class="avatar-dropdown-item avatar-dropdown-logout"
 					@click="handleLogout"

--- a/frontend/src/composables/useMailTemplates.ts
+++ b/frontend/src/composables/useMailTemplates.ts
@@ -60,6 +60,7 @@ export function useMailTemplates() {
 		department: Department,
 		subject: string,
 		body: string,
+		recipients: string[] = [],
 	): Promise<MailTemplate | null> {
 		error.value = null;
 		try {
@@ -67,7 +68,7 @@ export function useMailTemplates() {
 				`${BASE}/mail-templates/${encodeURIComponent(department)}`,
 				{
 					method: 'PUT',
-					body: JSON.stringify({ subject, body }),
+					body: JSON.stringify({ subject, body, recipients }),
 				},
 			);
 			if (!res.ok) throw new Error(await res.text());

--- a/frontend/src/pages/MailComposerPage.vue
+++ b/frontend/src/pages/MailComposerPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useActivities } from '../composables/useActivities';
 import { useMailTemplates } from '../composables/useMailTemplates';
@@ -19,10 +19,27 @@ const body = ref('')
 const recipients = ref<string[]>([''])
 const sent = ref(false)
 const loadError = ref<string | null>(null)
+const editorRef = ref<HTMLElement | null>(null)
+const curFont = ref('Arial')
+const curSize = ref('12')
+const curColor = ref('#000000')
+const curBold = ref(false)
+const curItalic = ref(false)
+const curUnderline = ref(false)
+const curUl = ref(false)
+const curOl = ref(false)
+const curBgColor = ref('#ffffff')
+let savedSelection: Range | null = null
 
 function formatDateLong(d: string): string {
   return new Date(d + 'T00:00:00').toLocaleDateString('de-DE', {
     weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'
+  })
+}
+
+function formatDateShort(d: string): string {
+  return new Date(d + 'T00:00:00').toLocaleDateString('de-DE', {
+    day: '2-digit', month: '2-digit', year: 'numeric'
   })
 }
 
@@ -34,18 +51,40 @@ function formatPrograms(act: Activity): string {
 }
 
 function replaceTemplateVars(text: string, act: Activity): string {
-  return text
-    .replace(/\{\{titel\}\}/gi,            act.title)
-    .replace(/\{\{datum\}\}/gi,            formatDateLong(act.date))
-    .replace(/\{\{startzeit\}\}/gi,        act.start_time)
-    .replace(/\{\{endzeit\}\}/gi,          act.end_time)
-    .replace(/\{\{ort\}\}/gi,              act.location)
-    .replace(/\{\{verantwortlich\}\}/gi,   act.responsible.join(', '))
-    .replace(/\{\{abteilung\}\}/gi,        act.department ?? '—')
-    .replace(/\{\{ziel\}\}/gi,             act.goal)
-    .replace(/\{\{material\}\}/gi,         act.material.map(m => m.name).join(', ') || '—')
-    .replace(/\{\{schlechtwetter\}\}/gi,   act.bad_weather_info ?? '—')
-    .replace(/\{\{programm\}\}/gi,         formatPrograms(act))
+  // Use a temporary DOM element to do replacements while preserving formatting.
+  // Walking text nodes means <font face="Arial">{{titel}}</font> keeps its font.
+  const container = document.createElement('div')
+  container.innerHTML = text
+  const senderEmail = user.value?.email ?? ''
+  const senderName = user.value?.display_name ?? ''
+  const vars: Record<string, string> = {
+    titel: act.title,
+    datum: formatDateLong(act.date),
+    datum_kurz: formatDateShort(act.date),
+    startzeit: act.start_time,
+    endzeit: act.end_time,
+    ort: act.location,
+    verantwortlich: act.responsible.join(', '),
+    abteilung: act.department ?? '—',
+    ziel: act.goal,
+    material: act.material.map(m => m.name).join(', ') || '—',
+    schlechtwetter: act.bad_weather_info ?? '—',
+    programm: formatPrograms(act),
+    absender_email: senderEmail,
+    absender_name: senderName,
+  }
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+  const textNodes: Text[] = []
+  while (walker.nextNode()) textNodes.push(walker.currentNode as Text)
+  for (const node of textNodes) {
+    const original = node.nodeValue ?? ''
+    const replaced = original.replace(/\{\{(\w+)\}\}/gi, (m, key) => {
+      const lk = key.toLowerCase()
+      return lk in vars ? vars[lk] : m
+    })
+    if (replaced !== original) node.nodeValue = replaced
+  }
+  return container.innerHTML
 }
 
 onMounted(async () => {
@@ -61,9 +100,150 @@ onMounted(async () => {
     if (tpl) {
       subject.value = replaceTemplateVars(tpl.subject, act)
       body.value    = replaceTemplateVars(tpl.body, act)
+      if (tpl.recipients?.length) {
+        recipients.value = [...tpl.recipients]
+      }
     }
   }
+  nextTick(() => {
+    if (editorRef.value) editorRef.value.innerHTML = body.value
+  })
 })
+
+function onEditorInput() {
+  if (editorRef.value) body.value = editorRef.value.innerHTML
+  updateToolbarState()
+}
+
+function updateToolbarState() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const node = sel.anchorNode?.nodeType === 3 ? sel.anchorNode.parentElement : sel.anchorNode as HTMLElement
+  if (!node || !editorRef.value.contains(node)) return
+  const cs = window.getComputedStyle(node)
+  curFont.value = cs.fontFamily.replace(/["']/g, '').split(',')[0].trim() || 'Arial'
+  curSize.value = parseInt(cs.fontSize).toString() || '12'
+  curColor.value = rgbToHex(cs.color) || '#000000'
+  const bgRaw = cs.backgroundColor
+  curBgColor.value = (bgRaw === 'rgba(0, 0, 0, 0)' || bgRaw === 'transparent') ? '#ffffff' : (rgbToHex(bgRaw) || '#ffffff')
+  curBold.value = document.queryCommandState('bold')
+  curItalic.value = document.queryCommandState('italic')
+  curUnderline.value = document.queryCommandState('underline')
+  curUl.value = document.queryCommandState('insertUnorderedList')
+  curOl.value = document.queryCommandState('insertOrderedList')
+}
+
+function rgbToHex(rgb: string): string {
+  const m = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/)
+  if (!m) return rgb
+  return '#' + [m[1], m[2], m[3]].map(x => parseInt(x).toString(16).padStart(2, '0')).join('')
+}
+
+function expandSelectionToVariables() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const range = sel.getRangeAt(0)
+  const container = editorRef.value
+  const fullText = container.textContent ?? ''
+  function nodeOffset(node: Node, off: number): number {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      if (walker.currentNode === node) return pos + off
+      pos += (walker.currentNode as Text).length
+    }
+    return pos
+  }
+  function offsetToNodePos(target: number): { node: Text; offset: number } | null {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      const t = walker.currentNode as Text
+      if (pos + t.length >= target) return { node: t, offset: target - pos }
+      pos += t.length
+    }
+    return null
+  }
+  let startOff = nodeOffset(range.startContainer, range.startOffset)
+  let endOff = nodeOffset(range.endContainer, range.endOffset)
+  const varPattern = /\{\{\w+\}\}/g
+  let m: RegExpExecArray | null
+  while ((m = varPattern.exec(fullText)) !== null) {
+    const vs = m.index, ve = m.index + m[0].length
+    if (startOff > vs && startOff < ve) startOff = vs
+    if (endOff > vs && endOff < ve) endOff = ve
+  }
+  const newStart = offsetToNodePos(startOff)
+  const newEnd = offsetToNodePos(endOff)
+  if (newStart && newEnd) {
+    range.setStart(newStart.node, newStart.offset)
+    range.setEnd(newEnd.node, newEnd.offset)
+    sel.removeAllRanges()
+    sel.addRange(range)
+  }
+}
+
+function execCmd(cmd: string, value?: string) {
+  if (savedSelection) {
+    const sel = window.getSelection()
+    if (sel) { sel.removeAllRanges(); sel.addRange(savedSelection) }
+    savedSelection = null
+  }
+  expandSelectionToVariables()
+  document.execCommand(cmd, false, value)
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function saveSelection() {
+  const sel = window.getSelection()
+  if (sel?.rangeCount && editorRef.value?.contains(sel.anchorNode)) {
+    savedSelection = sel.getRangeAt(0).cloneRange()
+  }
+}
+
+function setFontSize(size: string) {
+  expandSelectionToVariables()
+  document.execCommand('fontSize', false, '7')
+  const fontEls = editorRef.value?.querySelectorAll('font[size="7"]')
+  const newSpans: HTMLElement[] = []
+  fontEls?.forEach(el => {
+    const span = document.createElement('span')
+    span.style.fontSize = size + 'px'
+    span.innerHTML = el.innerHTML
+    el.replaceWith(span)
+    newSpans.push(span)
+  })
+  if (newSpans.length) {
+    const sel = window.getSelection()
+    if (sel) {
+      const range = document.createRange()
+      const tw1 = document.createTreeWalker(newSpans[0], NodeFilter.SHOW_TEXT)
+      const firstText = tw1.nextNode()
+      const lastSpan = newSpans[newSpans.length - 1]
+      const tw2 = document.createTreeWalker(lastSpan, NodeFilter.SHOW_TEXT)
+      let lastText: Node | null = null
+      while (tw2.nextNode()) lastText = tw2.currentNode
+      if (firstText && lastText) {
+        range.setStart(firstText, 0)
+        range.setEnd(lastText, (lastText as Text).length)
+        sel.removeAllRanges()
+        sel.addRange(range)
+      }
+    }
+  }
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function adjustFontSize(delta: number) {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const current = parseInt(curSize.value) || 12
+  const newSize = Math.max(8, Math.min(72, current + delta))
+  setFontSize(String(newSize))
+  curSize.value = String(newSize)
+}
 
 function addRecipient() {
 	recipients.value.push('');
@@ -79,7 +259,7 @@ async function handleSend() {
 		return;
 
 	const fromEmail = user.value?.email ?? '';
-	const bodyHtml = body.value.replace(/\n/g, '<br>');
+	const bodyHtml = body.value;
 
 	const ok = await sendMail(validTo, subject.value, bodyHtml, fromEmail);
 	if (ok) sent.value = true;
@@ -157,7 +337,48 @@ async function handleSend() {
 			<!-- Body -->
 			<div class="form-group">
 				<label>Nachricht <span class="required">*</span></label>
-				<textarea v-model="body" rows="12" required></textarea>
+				<div class="rich-editor-toolbar">
+					<select class="toolbar-select" :value="curFont" @change="execCmd('fontName', ($event.target as HTMLSelectElement).value)" title="Schriftart">
+						<option value="" disabled>Schriftart</option>
+						<option value="Arial" style="font-family:Arial">Arial</option>
+						<option value="Helvetica" style="font-family:Helvetica">Helvetica</option>
+						<option value="Georgia" style="font-family:Georgia">Georgia</option>
+						<option value="Times New Roman" style="font-family:'Times New Roman'">Times New Roman</option>
+						<option value="Courier New" style="font-family:'Courier New'">Courier New</option>
+						<option value="Verdana" style="font-family:Verdana">Verdana</option>
+						<option value="Trebuchet MS" style="font-family:'Trebuchet MS'">Trebuchet MS</option>
+					</select>
+					<input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+					<button type="button" class="toolbar-btn-sm" @click="adjustFontSize(-2)" title="Kleiner">A−</button>
+					<button type="button" class="toolbar-btn-sm" @click="adjustFontSize(2)" title="Grösser">A+</button>
+					<span class="toolbar-sep"></span>
+					<button type="button" :class="{'toolbar-btn--active': curBold}" @click="execCmd('bold')" title="Fett"><b>B</b></button>
+					<button type="button" :class="{'toolbar-btn--active': curItalic}" @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
+					<button type="button" :class="{'toolbar-btn--active': curUnderline}" @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
+					<span class="toolbar-sep"></span>
+					<label class="toolbar-color" title="Schriftfarbe" @mousedown="saveSelection">
+						A
+						<input type="color" :value="curColor" @input="execCmd('foreColor', ($event.target as HTMLInputElement).value)" />
+					</label>
+					<label class="toolbar-color toolbar-color--bg" title="Hintergrundfarbe" @mousedown="saveSelection">
+						<span class="toolbar-color-icon">A</span>
+						<input type="color" :value="curBgColor" @input="execCmd('hiliteColor', ($event.target as HTMLInputElement).value)" />
+					</label>
+					<span class="toolbar-sep"></span>
+					<button type="button" :class="{'toolbar-btn--active': curUl}" @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
+					<button type="button" :class="{'toolbar-btn--active': curOl}" @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+					<span class="toolbar-sep"></span>
+					<button type="button" @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
+				</div>
+				<div
+					ref="editorRef"
+					class="rich-editor"
+					contenteditable="true"
+					@input="onEditorInput"
+					@mouseup="updateToolbarState"
+					@keyup="updateToolbarState"
+					data-placeholder="Nachricht…"
+				></div>
 			</div>
 
 			<p v-if="error" class="error">{{ error }}</p>

--- a/frontend/src/pages/MailTemplatePage.vue
+++ b/frontend/src/pages/MailTemplatePage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, nextTick } from 'vue'
 import { useMailTemplates } from '../composables/useMailTemplates'
 import { user } from '../composables/useAuth'
 import type { Department } from '../types'
@@ -8,7 +8,8 @@ const ALL_DEPARTMENTS: Department[] = ['Leiter', 'Pio', 'Pfadi', 'Wölfe', 'Bibe
 
 const TEMPLATE_VARIABLES = [
   { var: '{{titel}}',            desc: 'Titel der Aktivität' },
-  { var: '{{datum}}',            desc: 'Datum (z.B. Samstag, 12. April 2026)' },
+  { var: '{{datum}}',            desc: 'Datum lang (z.B. Samstag, 12. April 2026)' },
+  { var: '{{datum_kurz}}',       desc: 'Datum kurz (z.B. 12.04.2026)' },
   { var: '{{startzeit}}',        desc: 'Startzeit (HH:MM)' },
   { var: '{{endzeit}}',          desc: 'Endzeit (HH:MM)' },
   { var: '{{ort}}',              desc: 'Veranstaltungsort' },
@@ -18,6 +19,8 @@ const TEMPLATE_VARIABLES = [
   { var: '{{material}}',         desc: 'Materialliste (kommagetrennt)' },
   { var: '{{schlechtwetter}}',   desc: 'Schlechtwetter-Info' },
   { var: '{{programm}}',         desc: 'Programmpunkte (formatiert)' },
+  { var: '{{absender_email}}',   desc: 'E-Mail-Adresse des Absenders' },
+  { var: '{{absender_name}}',    desc: 'Voller Name des Absenders (z.B. Leandro Klaus v/o Topo)' },
 ]
 
 const { fetchTemplates, saveTemplate, templates, loading, error } = useMailTemplates()
@@ -25,7 +28,6 @@ const { fetchTemplates, saveTemplate, templates, loading, error } = useMailTempl
 const isAdmin        = computed(() => user.value?.role === 'admin')
 const isStufenleiter = computed(() => user.value?.role === 'Stufenleiter')
 
-// Stufenleiter sees only own dept; admin sees all
 const visibleDepartments = computed<Department[]>(() => {
   if (isStufenleiter.value) {
     const own = user.value?.department as Department | undefined
@@ -34,7 +36,6 @@ const visibleDepartments = computed<Department[]>(() => {
   return ALL_DEPARTMENTS
 })
 
-// Default: own dept for Stufenleiter, first dept otherwise
 const activeDept = ref<Department>(
   isStufenleiter.value && user.value?.department
     ? user.value.department as Department
@@ -43,9 +44,21 @@ const activeDept = ref<Department>(
 
 const subject = ref('')
 const body = ref('')
+const recipients = ref<string[]>([''])
 const saving = ref(false)
 const saved = ref(false)
 const showVars = ref(false)
+const editorRef = ref<HTMLElement | null>(null)
+const curFont = ref('Arial')
+const curSize = ref('12')
+const curColor = ref('#000000')
+const curBold = ref(false)
+const curItalic = ref(false)
+const curUnderline = ref(false)
+const curUl = ref(false)
+const curOl = ref(false)
+const curBgColor = ref('#ffffff')
+let savedSelection: Range | null = null
 
 onMounted(async () => {
   await fetchTemplates()
@@ -58,12 +71,162 @@ function loadDept(dept: Department) {
   const tpl = templates.value.find(t => t.department === dept)
   subject.value = tpl?.subject ?? ''
   body.value    = tpl?.body ?? ''
+  recipients.value = tpl?.recipients?.length ? [...tpl.recipients] : ['']
+  nextTick(() => {
+    if (editorRef.value) editorRef.value.innerHTML = body.value
+  })
+}
+
+function onEditorInput() {
+  if (editorRef.value) body.value = editorRef.value.innerHTML
+  updateToolbarState()
+}
+
+function updateToolbarState() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const node = sel.anchorNode?.nodeType === 3 ? sel.anchorNode.parentElement : sel.anchorNode as HTMLElement
+  if (!node || !editorRef.value.contains(node)) return
+  const cs = window.getComputedStyle(node)
+  curFont.value = cs.fontFamily.replace(/["']/g, '').split(',')[0].trim() || 'Arial'
+  curSize.value = parseInt(cs.fontSize).toString() || '12'
+  curColor.value = rgbToHex(cs.color) || '#000000'
+  const bgRaw = cs.backgroundColor
+  curBgColor.value = (bgRaw === 'rgba(0, 0, 0, 0)' || bgRaw === 'transparent') ? '#ffffff' : (rgbToHex(bgRaw) || '#ffffff')
+  curBold.value = document.queryCommandState('bold')
+  curItalic.value = document.queryCommandState('italic')
+  curUnderline.value = document.queryCommandState('underline')
+  curUl.value = document.queryCommandState('insertUnorderedList')
+  curOl.value = document.queryCommandState('insertOrderedList')
+}
+
+function rgbToHex(rgb: string): string {
+  const m = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/)
+  if (!m) return rgb
+  return '#' + [m[1], m[2], m[3]].map(x => parseInt(x).toString(16).padStart(2, '0')).join('')
+}
+
+function expandSelectionToVariables() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const range = sel.getRangeAt(0)
+  const container = editorRef.value
+  const fullText = container.textContent ?? ''
+  // Map range start/end to text offsets, then expand if inside a {{...}}
+  function nodeOffset(node: Node, off: number): number {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      if (walker.currentNode === node) return pos + off
+      pos += (walker.currentNode as Text).length
+    }
+    return pos
+  }
+  function offsetToNodePos(target: number): { node: Text; offset: number } | null {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      const t = walker.currentNode as Text
+      if (pos + t.length >= target) return { node: t, offset: target - pos }
+      pos += t.length
+    }
+    return null
+  }
+  let startOff = nodeOffset(range.startContainer, range.startOffset)
+  let endOff = nodeOffset(range.endContainer, range.endOffset)
+  // Expand start backwards if inside a variable
+  const varPattern = /\{\{\w+\}\}/g
+  let m: RegExpExecArray | null
+  while ((m = varPattern.exec(fullText)) !== null) {
+    const vs = m.index, ve = m.index + m[0].length
+    if (startOff > vs && startOff < ve) startOff = vs
+    if (endOff > vs && endOff < ve) endOff = ve
+  }
+  const newStart = offsetToNodePos(startOff)
+  const newEnd = offsetToNodePos(endOff)
+  if (newStart && newEnd) {
+    range.setStart(newStart.node, newStart.offset)
+    range.setEnd(newEnd.node, newEnd.offset)
+    sel.removeAllRanges()
+    sel.addRange(range)
+  }
+}
+
+function execCmd(cmd: string, value?: string) {
+  if (savedSelection) {
+    const sel = window.getSelection()
+    if (sel) { sel.removeAllRanges(); sel.addRange(savedSelection) }
+    savedSelection = null
+  }
+  expandSelectionToVariables()
+  document.execCommand(cmd, false, value)
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function saveSelection() {
+  const sel = window.getSelection()
+  if (sel?.rangeCount && editorRef.value?.contains(sel.anchorNode)) {
+    savedSelection = sel.getRangeAt(0).cloneRange()
+  }
+}
+
+function setFontSize(size: string) {
+  expandSelectionToVariables()
+  document.execCommand('fontSize', false, '7')
+  const fontEls = editorRef.value?.querySelectorAll('font[size="7"]')
+  const newSpans: HTMLElement[] = []
+  fontEls?.forEach(el => {
+    const span = document.createElement('span')
+    span.style.fontSize = size + 'px'
+    span.innerHTML = el.innerHTML
+    el.replaceWith(span)
+    newSpans.push(span)
+  })
+  if (newSpans.length) {
+    const sel = window.getSelection()
+    if (sel) {
+      const range = document.createRange()
+      const tw1 = document.createTreeWalker(newSpans[0], NodeFilter.SHOW_TEXT)
+      const firstText = tw1.nextNode()
+      const lastSpan = newSpans[newSpans.length - 1]
+      const tw2 = document.createTreeWalker(lastSpan, NodeFilter.SHOW_TEXT)
+      let lastText: Node | null = null
+      while (tw2.nextNode()) lastText = tw2.currentNode
+      if (firstText && lastText) {
+        range.setStart(firstText, 0)
+        range.setEnd(lastText, (lastText as Text).length)
+        sel.removeAllRanges()
+        sel.addRange(range)
+      }
+    }
+  }
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function adjustFontSize(delta: number) {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const current = parseInt(curSize.value) || 12
+  const newSize = Math.max(8, Math.min(72, current + delta))
+  setFontSize(String(newSize))
+  curSize.value = String(newSize)
+}
+
+function addRecipient() {
+  recipients.value.push('')
+}
+
+function removeRecipient(index: number) {
+  recipients.value.splice(index, 1)
 }
 
 async function handleSave() {
   saving.value = true
   saved.value  = false
-  const result = await saveTemplate(activeDept.value, subject.value, body.value)
+  const validRecipients = recipients.value.map(r => r.trim()).filter(Boolean)
+  const result = await saveTemplate(activeDept.value, subject.value, body.value, validRecipients)
   saving.value = false
   if (result) {
     saved.value = true
@@ -100,6 +263,27 @@ async function handleSave() {
     <p v-if="loading" class="loading">Laden...</p>
 
     <form v-else class="detail-form" @submit.prevent="handleSave">
+      <!-- Recipients -->
+      <div class="form-group">
+        <label>Empfänger</label>
+        <div class="mail-recipients">
+          <div v-for="(_, i) in recipients" :key="i" class="mail-recipient-row">
+            <input
+              v-model="recipients[i]"
+              type="email"
+              placeholder="email@example.com"
+            />
+            <button
+              v-if="recipients.length > 1"
+              type="button"
+              class="btn-remove-sm"
+              @click="removeRecipient(i)"
+            >×</button>
+          </div>
+          <button type="button" class="btn-add" @click="addRecipient">+ Empfänger</button>
+        </div>
+      </div>
+
       <div class="form-group">
         <label>Betreff-Vorlage</label>
         <input v-model="subject" type="text" placeholder="Betreff…" />
@@ -107,7 +291,48 @@ async function handleSave() {
 
       <div class="form-group">
         <label>Nachricht-Vorlage</label>
-        <textarea v-model="body" rows="14" placeholder="Mail-Text…"></textarea>
+        <div class="rich-editor-toolbar">
+          <select class="toolbar-select" :value="curFont" @change="execCmd('fontName', ($event.target as HTMLSelectElement).value)" title="Schriftart">
+            <option value="" disabled>Schriftart</option>
+            <option value="Arial" style="font-family:Arial">Arial</option>
+            <option value="Helvetica" style="font-family:Helvetica">Helvetica</option>
+            <option value="Georgia" style="font-family:Georgia">Georgia</option>
+            <option value="Times New Roman" style="font-family:'Times New Roman'">Times New Roman</option>
+            <option value="Courier New" style="font-family:'Courier New'">Courier New</option>
+            <option value="Verdana" style="font-family:Verdana">Verdana</option>
+            <option value="Trebuchet MS" style="font-family:'Trebuchet MS'">Trebuchet MS</option>
+          </select>
+          <input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+          <button type="button" class="toolbar-btn-sm" @click="adjustFontSize(-2)" title="Kleiner">A−</button>
+          <button type="button" class="toolbar-btn-sm" @click="adjustFontSize(2)" title="Grösser">A+</button>
+          <span class="toolbar-sep"></span>
+          <button type="button" :class="{'toolbar-btn--active': curBold}" @click="execCmd('bold')" title="Fett"><b>B</b></button>
+          <button type="button" :class="{'toolbar-btn--active': curItalic}" @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
+          <button type="button" :class="{'toolbar-btn--active': curUnderline}" @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
+          <span class="toolbar-sep"></span>
+          <label class="toolbar-color" title="Schriftfarbe" @mousedown="saveSelection">
+            A
+            <input type="color" :value="curColor" @input="execCmd('foreColor', ($event.target as HTMLInputElement).value)" />
+          </label>
+          <label class="toolbar-color toolbar-color--bg" title="Hintergrundfarbe" @mousedown="saveSelection">
+            <span class="toolbar-color-icon">A</span>
+            <input type="color" :value="curBgColor" @input="execCmd('hiliteColor', ($event.target as HTMLInputElement).value)" />
+          </label>
+          <span class="toolbar-sep"></span>
+          <button type="button" :class="{'toolbar-btn--active': curUl}" @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
+          <button type="button" :class="{'toolbar-btn--active': curOl}" @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+          <span class="toolbar-sep"></span>
+          <button type="button" @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
+        </div>
+        <div
+          ref="editorRef"
+          class="rich-editor"
+          contenteditable="true"
+          @input="onEditorInput"
+          @mouseup="updateToolbarState"
+          @keyup="updateToolbarState"
+          data-placeholder="Mail-Text…"
+        ></div>
       </div>
 
       <!-- Variable reference -->

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -96,6 +96,7 @@ export interface MailTemplate {
 	department: Department;
 	subject: string;
 	body: string;
+	recipients: string[];
 	created_at: string;
 	updated_at: string;
 }


### PR DESCRIPTION
…blen

Änderungen:
- Mail-Vorlagen Link aus UserAvatar-Dropdown entfernt
- Empfänger-Feld auf Mail-Vorlagen-Seite hinzugefügt (werden automatisch in neue Mails übernommen)
- Textfeld durch Rich-Text-Editor ersetzt (contenteditable + Toolbar)
- Toolbar: Schriftart, Grösse (freies Textfeld + A±-Buttons), Fett, Kursiv, Unterstrichen, Schrift-/Hintergrundfarbe, Listen, Format entfernen
- Neue Template-Variablen: {{absender_email}}, {{absender_name}}, {{datum_kurz}}
- Variablen-Ersetzung via DOM-TreeWalker (erhält Formatierung)
- Variablen werden atomar formatiert (Selektion wird automatisch auf ganze {{variable}} erweitert)
- Selektion bleibt bei Grössenänderung und Farbwahl erhalten
- Toolbar zeigt aktiven Zustand aller Formatierungen (Bold/Italic/Underline/Listen/Farben/Grösse)
- Backend: recipients-Feld in mail_templates (TEXT[])
- Seed-Daten mit HTML-Body und Empfängern aktualisiert

Zu testen:
- [x] Mail-Vorlagen bearbeiten: Empfänger hinzufügen/entfernen, Speichern & Neuladen
- [ ] Rich-Editor: Text markieren → Schriftart/Grösse/Farbe/Fett/Kursiv/Unterstrichen ändern
- [ ] Grössen-Buttons (A−/A+): Mehrfach hintereinander klicken, Text muss markiert bleiben
- [ ] Hintergrundfarbe: Text markieren → Farbe wählen → Selektion darf nicht verloren gehen
- [ ] Variablen (z.B. {{titel}}): Teilweise markieren → Formatierung muss ganze Variable umfassen
- [ ] Mail senden: Vorlage mit Variablen + Formatierung laden → Variablen korrekt ersetzt, Formatierung erhalten
- [ ] Empfänger aus Vorlage werden beim Öffnen des Mail-Formulars vorausgefüllt
- [ ] Toolbar-Status: Cursor in formatierten Text setzen → Toolbar zeigt aktuelle Werte (Schrift, Grösse, Farbe, B/I/U)