### PR TITLE
feat: Mail-Vorlagen überarbeiten – Rich-Editor, Empfänger, neue Varia…

### DIFF
--- a/backend/src/db.cpp
+++ b/backend/src/db.cpp
@@ -403,14 +403,14 @@ std::optional<Activity> Database::create_activity(const ActivityInput &input)
                 mat_json.c_str(), needs_s,
                 input.siko_base64->c_str()};
             PGresult *r = PQexecParams(conn_,
-                "INSERT INTO activities "
-                "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, siko) "
-                "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
-                "$8::department_enum, $9::jsonb, $10, decode($11, 'base64')) "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                11, nullptr, p2, nullptr, nullptr, 0);
+                                       "INSERT INTO activities "
+                                       "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, siko) "
+                                       "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "$8::department_enum, $9::jsonb, $10, decode($11, 'base64')) "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       11, nullptr, p2, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -432,14 +432,14 @@ std::optional<Activity> Database::create_activity(const ActivityInput &input)
                 mat_json.c_str(), needs_s,
                 bwi_str.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "INSERT INTO activities "
-                "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, bad_weather_info) "
-                "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
-                "$8::department_enum, $9::jsonb, $10, $11) "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                11, nullptr, p, nullptr, nullptr, 0);
+                                       "INSERT INTO activities "
+                                       "(title, date, start_time, end_time, goal, location, responsible, department, material, needs_siko, bad_weather_info) "
+                                       "VALUES ($1, $2::date, $3, $4, $5, $6, array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "$8::department_enum, $9::jsonb, $10, $11) "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       11, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -495,16 +495,16 @@ std::optional<Activity> Database::update_activity(const std::string &id, const A
                 input.siko_base64->c_str(),
                 bwi_str.c_str(), id.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "UPDATE activities SET "
-                "title=$1, date=$2::date, start_time=$3, end_time=$4, "
-                "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
-                "department=$8::department_enum, material=$9::jsonb, "
-                "needs_siko=$10, siko=decode($11, 'base64'), bad_weather_info=$12 "
-                "WHERE id=$13 "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                13, nullptr, p, nullptr, nullptr, 0);
+                                       "UPDATE activities SET "
+                                       "title=$1, date=$2::date, start_time=$3, end_time=$4, "
+                                       "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "department=$8::department_enum, material=$9::jsonb, "
+                                       "needs_siko=$10, siko=decode($11, 'base64'), bad_weather_info=$12 "
+                                       "WHERE id=$13 "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       13, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -528,16 +528,16 @@ std::optional<Activity> Database::update_activity(const std::string &id, const A
                 mat_json.c_str(), needs_s,
                 bwi_str.c_str(), id.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "UPDATE activities SET "
-                "title=$1, date=$2::date, start_time=$3, end_time=$4, "
-                "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
-                "department=$8::department_enum, material=$9::jsonb, "
-                "needs_siko=$10, siko=NULL, bad_weather_info=$11 "
-                "WHERE id=$12 "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                12, nullptr, p, nullptr, nullptr, 0);
+                                       "UPDATE activities SET "
+                                       "title=$1, date=$2::date, start_time=$3, end_time=$4, "
+                                       "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "department=$8::department_enum, material=$9::jsonb, "
+                                       "needs_siko=$10, siko=NULL, bad_weather_info=$11 "
+                                       "WHERE id=$12 "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       12, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -562,16 +562,16 @@ std::optional<Activity> Database::update_activity(const std::string &id, const A
                 mat_json.c_str(), needs_s,
                 bwi_str.c_str(), id.c_str()};
             PGresult *r = PQexecParams(conn_,
-                "UPDATE activities SET "
-                "title=$1, date=$2::date, start_time=$3, end_time=$4, "
-                "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
-                "department=$8::department_enum, material=$9::jsonb, "
-                "needs_siko=$10, bad_weather_info=$11 "
-                "WHERE id=$12 "
-                "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
-                "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
-                "bad_weather_info, created_at, updated_at",
-                12, nullptr, p, nullptr, nullptr, 0);
+                                       "UPDATE activities SET "
+                                       "title=$1, date=$2::date, start_time=$3, end_time=$4, "
+                                       "goal=$5, location=$6, responsible=array(select jsonb_array_elements_text($7::jsonb)), "
+                                       "department=$8::department_enum, material=$9::jsonb, "
+                                       "needs_siko=$10, bad_weather_info=$11 "
+                                       "WHERE id=$12 "
+                                       "RETURNING id, title, date::text, start_time, end_time, goal, location, responsible, "
+                                       "department::text, material, needs_siko, (siko IS NOT NULL) AS has_siko, "
+                                       "bad_weather_info, created_at, updated_at",
+                                       12, nullptr, p, nullptr, nullptr, 0);
             if (PQresultStatus(r) != PGRES_TUPLES_OK || PQntuples(r) == 0)
             {
                 std::string err = PQresultErrorMessage(r);
@@ -681,7 +681,8 @@ std::optional<UserRecord> Database::upsert_user(const std::string &oid,
     {
         on_conflict =
             "ON CONFLICT (microsoft_oid) DO UPDATE "
-            "SET email = EXCLUDED.email, role = '" + initial_role + "'::user_role, updated_at = NOW() ";
+            "SET email = EXCLUDED.email, role = '" +
+            initial_role + "'::user_role, updated_at = NOW() ";
     }
     else
     {
@@ -692,7 +693,8 @@ std::optional<UserRecord> Database::upsert_user(const std::string &oid,
 
     std::string sql =
         "INSERT INTO users (microsoft_oid, email, display_name, department, role) "
-        "VALUES ($1, $2, $3, '" + initial_dept + "'::department_enum, '" + initial_role + "'::user_role) " +
+        "VALUES ($1, $2, $3, '" +
+        initial_dept + "'::department_enum, '" + initial_role + "'::user_role) " +
         on_conflict +
         "RETURNING id, microsoft_oid, email, display_name, department::text, role::text, created_at, updated_at";
 
@@ -782,9 +784,9 @@ std::optional<UserRecord> Database::update_user(const std::string &oid,
 // ---- update_user_admin ------------------------------------------------------
 
 std::optional<UserRecord> Database::update_user_admin(const std::string &id,
-                                                       const std::string &display_name,
-                                                       const std::optional<std::string> &department,
-                                                       const std::string &role)
+                                                      const std::string &display_name,
+                                                      const std::optional<std::string> &department,
+                                                      const std::string &role)
 {
     ensure_connected();
     std::string dept_str = department ? *department : "";
@@ -825,6 +827,8 @@ MailTemplate Database::row_to_mail_template(PGresult *res, int row)
     t.department = col("department") ? col("department") : "";
     t.subject = col("subject") ? col("subject") : "";
     t.body = col("body") ? col("body") : "";
+    if (col("recipients"))
+        t.recipients = parse_pg_array(col("recipients"));
     t.created_at = col("created_at") ? col("created_at") : "";
     t.updated_at = col("updated_at") ? col("updated_at") : "";
     return t;
@@ -834,7 +838,7 @@ std::vector<MailTemplate> Database::list_mail_templates()
 {
     ensure_connected();
     PGresult *res = PQexec(conn_,
-                           "SELECT id, department::text, subject, body, created_at, updated_at "
+                           "SELECT id, department::text, subject, body, recipients, created_at, updated_at "
                            "FROM mail_templates ORDER BY department");
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -857,7 +861,7 @@ std::optional<MailTemplate> Database::get_mail_template_by_department(const std:
     ensure_connected();
     const char *params[1] = {department.c_str()};
     PGresult *res = PQexecParams(conn_,
-                                 "SELECT id, department::text, subject, body, created_at, updated_at "
+                                 "SELECT id, department::text, subject, body, recipients, created_at, updated_at "
                                  "FROM mail_templates WHERE department = $1::department_enum",
                                  1, nullptr, params, nullptr, nullptr, 0);
 
@@ -873,16 +877,26 @@ std::optional<MailTemplate> Database::get_mail_template_by_department(const std:
 
 std::optional<MailTemplate> Database::upsert_mail_template(const std::string &department,
                                                            const std::string &subject,
-                                                           const std::string &body)
+                                                           const std::string &body,
+                                                           const std::vector<std::string> &recipients)
 {
     ensure_connected();
-    const char *params[3] = {department.c_str(), subject.c_str(), body.c_str()};
+    // Build PostgreSQL text array literal for recipients
+    std::string recipients_arr = "{";
+    for (size_t i = 0; i < recipients.size(); ++i)
+    {
+        if (i > 0)
+            recipients_arr += ",";
+        recipients_arr += "\"" + recipients[i] + "\"";
+    }
+    recipients_arr += "}";
+    const char *params[4] = {department.c_str(), subject.c_str(), body.c_str(), recipients_arr.c_str()};
     PGresult *res = PQexecParams(conn_,
-                                 "INSERT INTO mail_templates (department, subject, body) "
-                                 "VALUES ($1::department_enum, $2, $3) "
-                                 "ON CONFLICT (department) DO UPDATE SET subject = EXCLUDED.subject, body = EXCLUDED.body "
-                                 "RETURNING id, department::text, subject, body, created_at, updated_at",
-                                 3, nullptr, params, nullptr, nullptr, 0);
+                                 "INSERT INTO mail_templates (department, subject, body, recipients) "
+                                 "VALUES ($1::department_enum, $2, $3, $4::text[]) "
+                                 "ON CONFLICT (department) DO UPDATE SET subject = EXCLUDED.subject, body = EXCLUDED.body, recipients = EXCLUDED.recipients "
+                                 "RETURNING id, department::text, subject, body, recipients, created_at, updated_at",
+                                 4, nullptr, params, nullptr, nullptr, 0);
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK || PQntuples(res) == 0)
     {

--- a/backend/src/db.cpp
+++ b/backend/src/db.cpp
@@ -908,6 +908,87 @@ std::optional<MailTemplate> Database::upsert_mail_template(const std::string &de
     return t;
 }
 
+// ---- Sent mails log ---------------------------------------------------------
+
+SentMail Database::row_to_sent_mail(PGresult *res, int row)
+{
+    auto col = [&](const char *name) -> const char *
+    {
+        int c = PQfnumber(res, name);
+        if (c < 0 || PQgetisnull(res, row, c))
+            return nullptr;
+        return PQgetvalue(res, row, c);
+    };
+    SentMail m;
+    m.id = col("id") ? col("id") : "";
+    m.activity_id = col("activity_id") ? col("activity_id") : "";
+    m.sender_id = col("sender_id") ? col("sender_id") : "";
+    m.sender_email = col("sender_email") ? col("sender_email") : "";
+    if (col("to_emails"))
+        m.to_emails = parse_pg_array(col("to_emails"));
+    m.subject = col("subject") ? col("subject") : "";
+    m.body_html = col("body_html") ? col("body_html") : "";
+    m.sent_at = col("sent_at") ? col("sent_at") : "";
+    return m;
+}
+
+std::optional<SentMail> Database::log_sent_mail(const std::string &activity_id,
+                                                const std::string &sender_id,
+                                                const std::string &sender_email,
+                                                const std::vector<std::string> &to_emails,
+                                                const std::string &subject,
+                                                const std::string &body_html)
+{
+    ensure_connected();
+    std::string to_arr = "{";
+    for (size_t i = 0; i < to_emails.size(); ++i)
+    {
+        if (i > 0)
+            to_arr += ",";
+        to_arr += "\"" + to_emails[i] + "\"";
+    }
+    to_arr += "}";
+    const char *params[6] = {activity_id.c_str(), sender_id.c_str(), sender_email.c_str(),
+                             to_arr.c_str(), subject.c_str(), body_html.c_str()};
+    PGresult *res = PQexecParams(conn_,
+                                 "INSERT INTO sent_mails (activity_id, sender_id, sender_email, to_emails, subject, body_html) "
+                                 "VALUES ($1, $2, $3, $4::text[], $5, $6) "
+                                 "RETURNING id, activity_id, sender_id, sender_email, to_emails, subject, body_html, sent_at",
+                                 6, nullptr, params, nullptr, nullptr, 0);
+    if (PQresultStatus(res) != PGRES_TUPLES_OK || PQntuples(res) == 0)
+    {
+        std::string err = PQresultErrorMessage(res);
+        PQclear(res);
+        fprintf(stderr, "[log_sent_mail] %s\n", err.c_str());
+        return std::nullopt;
+    }
+    SentMail m = row_to_sent_mail(res, 0);
+    PQclear(res);
+    return m;
+}
+
+std::vector<SentMail> Database::list_sent_mails(const std::string &activity_id)
+{
+    ensure_connected();
+    const char *params[1] = {activity_id.c_str()};
+    PGresult *res = PQexecParams(conn_,
+                                 "SELECT id, activity_id, sender_id, sender_email, to_emails, subject, body_html, sent_at "
+                                 "FROM sent_mails WHERE activity_id = $1 ORDER BY sent_at DESC",
+                                 1, nullptr, params, nullptr, nullptr, 0);
+    if (PQresultStatus(res) != PGRES_TUPLES_OK)
+    {
+        PQclear(res);
+        return {};
+    }
+    std::vector<SentMail> out;
+    int n = PQntuples(res);
+    out.reserve(n);
+    for (int i = 0; i < n; ++i)
+        out.push_back(row_to_sent_mail(res, i));
+    PQclear(res);
+    return out;
+}
+
 // ---- send_mail via Microsoft Graph ------------------------------------------
 
 static size_t graph_write_cb(char *ptr, size_t size, size_t nmemb, void *userdata)

--- a/backend/src/db.hpp
+++ b/backend/src/db.hpp
@@ -23,6 +23,7 @@ struct MailTemplate
     std::string department;
     std::string subject;
     std::string body;
+    std::vector<std::string> recipients;
     std::string created_at;
     std::string updated_at;
 };
@@ -73,7 +74,8 @@ public:
     std::optional<MailTemplate> get_mail_template_by_department(const std::string &department);
     std::optional<MailTemplate> upsert_mail_template(const std::string &department,
                                                      const std::string &subject,
-                                                     const std::string &body);
+                                                     const std::string &body,
+                                                     const std::vector<std::string> &recipients);
 
     // Send mail via Microsoft Graph
     bool send_mail(const std::string &access_token,

--- a/backend/src/db.hpp
+++ b/backend/src/db.hpp
@@ -28,6 +28,18 @@ struct MailTemplate
     std::string updated_at;
 };
 
+struct SentMail
+{
+    std::string id;
+    std::string activity_id;
+    std::string sender_id;
+    std::string sender_email;
+    std::vector<std::string> to_emails;
+    std::string subject;
+    std::string body_html;
+    std::string sent_at;
+};
+
 class Database
 {
 public:
@@ -84,6 +96,15 @@ public:
                    const std::string &subject,
                    const std::string &body_html);
 
+    // Sent mails log
+    std::optional<SentMail> log_sent_mail(const std::string &activity_id,
+                                          const std::string &sender_id,
+                                          const std::string &sender_email,
+                                          const std::vector<std::string> &to_emails,
+                                          const std::string &subject,
+                                          const std::string &body_html);
+    std::vector<SentMail> list_sent_mails(const std::string &activity_id);
+
 private:
     PGconn *conn_{nullptr};
     void ensure_connected();
@@ -92,6 +113,7 @@ private:
     Program row_to_program(PGresult *res, int row);
     UserRecord row_to_user(PGresult *res, int row);
     MailTemplate row_to_mail_template(PGresult *res, int row);
+    SentMail row_to_sent_mail(PGresult *res, int row);
     void attach_programs(std::vector<Activity> &activities);
     void attach_programs_single(Activity &a);
 

--- a/backend/src/handlers.cpp
+++ b/backend/src/handlers.cpp
@@ -934,6 +934,7 @@ static nlohmann::json template_to_json(const MailTemplate &t)
         {"department", t.department},
         {"subject", t.subject},
         {"body", t.body},
+        {"recipients", t.recipients},
         {"created_at", t.created_at},
         {"updated_at", t.updated_at}};
 }
@@ -1038,8 +1039,16 @@ void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db)
         std::string subject = j.value("subject", "");
         std::string body    = j.value("body", "");
 
+        std::vector<std::string> recipients;
+        if (j.contains("recipients") && j["recipients"].is_array()) {
+            for (auto& e : j["recipients"]) {
+                if (e.is_string() && !e.get<std::string>().empty())
+                    recipients.push_back(e.get<std::string>());
+            }
+        }
+
         try {
-            auto tpl = db.upsert_mail_template(department, subject, body);
+            auto tpl = db.upsert_mail_template(department, subject, body, recipients);
             if (!tpl) {
                 send_json(res, 500, R"({"error":"db error"})");
                 return;

--- a/backend/src/handlers.cpp
+++ b/backend/src/handlers.cpp
@@ -986,7 +986,7 @@ void handle_get_mail_template(HttpRes *res, HttpReq *req, Database &db)
 
 // ---- PUT /mail-templates/:department ----------------------------------------
 
-void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db)
+void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm)
 {
     std::string auth_header{req->getHeader("authorization")};
     std::string token = extract_bearer_token(auth_header);
@@ -1025,7 +1025,7 @@ void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db)
     }
     auto buf = std::make_shared<std::string>();
     res->onAborted([] {});
-    res->onData([res, buf, department, &db](std::string_view chunk, bool last)
+    res->onData([res, buf, department, &db, &wm](std::string_view chunk, bool last)
                 {
         buf->append(chunk.data(), chunk.size());
         if (!last) return;
@@ -1053,6 +1053,8 @@ void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db)
                 send_json(res, 500, R"({"error":"db error"})");
                 return;
             }
+            nlohmann::json msg = {{"event", "template_updated"}, {"template", template_to_json(*tpl)}};
+            wm.broadcast(msg.dump());
             send_json(res, 200, template_to_json(*tpl).dump());
         } catch (std::exception& e) {
             send_json(res, 500, nlohmann::json{{"error", e.what()}}.dump());
@@ -1070,9 +1072,10 @@ void handle_post_send_mail(HttpRes *res, HttpReq *req, Database &db)
         send_json(res, 401, R"({"error":"Unauthorized"})");
         return;
     }
+    TokenClaims claims;
     try
     {
-        validate_token(token);
+        claims = validate_token(token);
     }
     catch (std::exception &e)
     {
@@ -1080,9 +1083,11 @@ void handle_post_send_mail(HttpRes *res, HttpReq *req, Database &db)
         return;
     }
 
+    auto current_user = resolve_user(db, claims);
+
     auto buf = std::make_shared<std::string>();
     res->onAborted([] {});
-    res->onData([res, buf, token, &db](std::string_view chunk, bool last)
+    res->onData([res, buf, token, &db, current_user](std::string_view chunk, bool last)
                 {
         buf->append(chunk.data(), chunk.size());
         if (!last) return;
@@ -1093,10 +1098,11 @@ void handle_post_send_mail(HttpRes *res, HttpReq *req, Database &db)
             return;
         }
 
-        std::string subject    = j.value("subject", "");
-        std::string body_html  = j.value("body", "");
-        std::string from_email = j.value("from", "");
+        std::string subject     = j.value("subject", "");
+        std::string body_html   = j.value("body", "");
+        std::string from_email  = j.value("from", "");
         std::string graph_token = j.value("access_token", "");
+        std::string activity_id = j.value("activity_id", "");
 
         if (subject.empty() || body_html.empty() || graph_token.empty()) {
             send_json(res, 400, R"({"error":"subject, body and access_token are required"})");
@@ -1118,6 +1124,12 @@ void handle_post_send_mail(HttpRes *res, HttpReq *req, Database &db)
         try {
             bool ok = db.send_mail(graph_token, from_email, to_emails, subject, body_html);
             if (ok) {
+                // Log sent mail if activity_id was provided
+                if (!activity_id.empty()) {
+                    std::string sender_id = current_user ? current_user->id : "";
+                    std::string sender_email = current_user ? current_user->email : from_email;
+                    db.log_sent_mail(activity_id, sender_id, sender_email, to_emails, subject, body_html);
+                }
                 send_json(res, 200, R"({"status":"sent"})");
             } else {
                 send_json(res, 502, R"({"error":"Failed to send mail via Microsoft Graph"})");
@@ -1125,6 +1137,38 @@ void handle_post_send_mail(HttpRes *res, HttpReq *req, Database &db)
         } catch (std::exception& e) {
             send_json(res, 500, nlohmann::json{{"error", e.what()}}.dump());
         } });
+}
+
+// ─── GET /activities/:id/sent-mails ──────────────────────────────────────────
+
+void handle_get_sent_mails(HttpRes *res, HttpReq *req, Database &db)
+{
+    TokenClaims claims;
+    if (!require_auth(res, req, claims))
+        return;
+
+    std::string activity_id{req->getParameter("id")};
+    auto mails = db.list_sent_mails(activity_id);
+
+    nlohmann::json arr = nlohmann::json::array();
+    for (auto &m : mails)
+    {
+        nlohmann::json to_arr = nlohmann::json::array();
+        for (auto &e : m.to_emails)
+            to_arr.push_back(e);
+
+        arr.push_back({
+            {"id", m.id},
+            {"activity_id", m.activity_id},
+            {"sender_id", m.sender_id},
+            {"sender_email", m.sender_email},
+            {"to_emails", to_arr},
+            {"subject", m.subject},
+            {"body_html", m.body_html},
+            {"sent_at", m.sent_at},
+        });
+    }
+    send_json(res, 200, arr.dump());
 }
 
 // ─── GitHub API helpers ───────────────────────────────────────────────────────

--- a/backend/src/handlers.hpp
+++ b/backend/src/handlers.hpp
@@ -42,8 +42,9 @@ void handle_debug_login(HttpRes *res, HttpReq *req, Database &db);
 // Mail template endpoints
 void handle_get_mail_templates(HttpRes *res, HttpReq *req, Database &db);
 void handle_get_mail_template(HttpRes *res, HttpReq *req, Database &db);
-void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db);
+void handle_put_mail_template(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
 void handle_post_send_mail(HttpRes *res, HttpReq *req, Database &db);
+void handle_get_sent_mails(HttpRes *res, HttpReq *req, Database &db);
 
 // Bug report (creates GitHub issue)
 void handle_post_bug_report(HttpRes *res, HttpReq *req, Database &db);

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -88,9 +88,11 @@ int main()
          .get("/mail-templates/:department", [&](auto *res, auto *req)
               { handle_get_mail_template(res, req, db); })
          .put("/mail-templates/:department", [&](auto *res, auto *req)
-              { handle_put_mail_template(res, req, db); })
+              { handle_put_mail_template(res, req, db, wm); })
          .post("/send-mail", [&](auto *res, auto *req)
                { handle_post_send_mail(res, req, db); })
+         .get("/activities/:id/sent-mails", [&](auto *res, auto *req)
+              { handle_get_sent_mails(res, req, db); })
 
          // Bug report — creates a GitHub issue
          .post("/bug-report", [&](auto *res, auto *req)

--- a/db/init.sql
+++ b/db/init.sql
@@ -73,6 +73,7 @@ CREATE TABLE mail_templates (
     department  department_enum NOT NULL UNIQUE,
     subject     TEXT            NOT NULL DEFAULT '',
     body        TEXT            NOT NULL DEFAULT '',
+    recipients  TEXT[]          NOT NULL DEFAULT '{}',
     created_at  TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
     updated_at  TIMESTAMPTZ     NOT NULL DEFAULT NOW()
 );
@@ -82,9 +83,9 @@ CREATE TRIGGER trg_mail_templates_updated_at
     FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
 
 -- Seed default (empty) templates for every department
-INSERT INTO mail_templates (department, subject, body) VALUES
-    ('Leiter', '', ''),
-    ('Pio',    '', ''),
-    ('Pfadi',  '', ''),
-    ('Wölfe',  '', ''),
-    ('Biber',  '', '');
+INSERT INTO mail_templates (department, subject, body, recipients) VALUES
+    ('Leiter', '', '', '{}'),
+    ('Pio',    '', '', '{}'),
+    ('Pfadi',  '', '', '{}'),
+    ('Wölfe',  '', '', '{}'),
+    ('Biber',  '', '', '{}');

--- a/db/init.sql
+++ b/db/init.sql
@@ -89,3 +89,17 @@ INSERT INTO mail_templates (department, subject, body, recipients) VALUES
     ('Pfadi',  '', '', '{}'),
     ('Wölfe',  '', '', '{}'),
     ('Biber',  '', '', '{}');
+
+-- Sent mail log (audit trail)
+CREATE TABLE sent_mails (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    activity_id  UUID        NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+    sender_id    UUID        REFERENCES users(id) ON DELETE SET NULL,
+    sender_email TEXT        NOT NULL,
+    to_emails    TEXT[]      NOT NULL,
+    subject      TEXT        NOT NULL,
+    body_html    TEXT        NOT NULL,
+    sent_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_sent_mails_activity_id ON sent_mails (activity_id);

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -120,10 +120,12 @@ INSERT INTO programs (activity_id, time, title, description, responsible) VALUES
 -- Mail-Templates mit Beispielinhalt
 UPDATE mail_templates SET
     subject = 'Einladung zur Pfadi-Aktivität: {{titel}}',
-    body = 'Liebe Eltern\n\nWir laden herzlich zur nächsten Aktivität ein:\n\n📅 Datum: {{datum}}\n🕐 Zeit: {{startzeit}} – {{endzeit}}\n📍 Ort: {{ort}}\n\nZiel: {{ziel}}\n\nBei Schlechtwetter: {{schlechtwetter}}\n\nFreundliche Grüsse\nDie Pfadileitung'
+    body = '<p>Liebe Eltern</p><p>Wir laden herzlich zur nächsten Aktivität ein:</p><p>📅 Datum: {{datum}}<br>🕐 Zeit: {{startzeit}} – {{endzeit}}<br>📍 Ort: {{ort}}</p><p>Ziel: {{ziel}}</p><p>Bei Schlechtwetter: {{schlechtwetter}}</p><p>Freundliche Grüsse<br>{{absender_name}}<br>{{absender_email}}</p>',
+    recipients = ARRAY['eltern-pfadi@pfadihue.ch']
 WHERE department = 'Pfadi';
 
 UPDATE mail_templates SET
     subject = 'Wölfe-Aktivität: {{titel}}',
-    body = 'Liebe Eltern\n\nDie nächste Wölfe-Aktivität steht an:\n\n📅 {{datum}}\n🕐 {{startzeit}} – {{endzeit}}\n📍 {{ort}}\n\nMitbringen: wetterfeste Kleidung, Zvieri\n\nBis bald!\nDas Wölfe-Team'
+    body = '<p>Liebe Eltern</p><p>Die nächste Wölfe-Aktivität steht an:</p><p>📅 {{datum_kurz}}<br>🕐 {{startzeit}} – {{endzeit}}<br>📍 {{ort}}</p><p>Mitbringen: wetterfeste Kleidung, Zvieri</p><p>Bis bald!<br>Das Wölfe-Team<br>{{absender_name}}</p>',
+    recipients = ARRAY['eltern-woelfe@pfadihue.ch']
 WHERE department = 'Wölfe';

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1495,3 +1495,188 @@ body {
 	font-size: 0.82rem;
 	color: #6b7280;
 }
+
+/* =============================================================================
+   RICH TEXT EDITOR — contenteditable with toolbar
+   ============================================================================= */
+
+.rich-editor-toolbar {
+	display: flex;
+	gap: 2px;
+	padding: 6px 8px;
+	background: #f9fafb;
+	border: 1px solid #d1d5db;
+	border-bottom: none;
+	border-radius: 8px 8px 0 0;
+	flex-wrap: wrap;
+}
+
+.rich-editor-toolbar button {
+	padding: 4px 10px;
+	font-size: 0.82rem;
+	font-family: inherit;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	color: #374151;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+	line-height: 1.4;
+}
+
+.rich-editor-toolbar button:hover {
+	background: #e8f0fe;
+	border-color: #0080ff;
+}
+
+.rich-editor-toolbar button.toolbar-btn--active,
+.toolbar-btn-sm.toolbar-btn--active {
+	background: #dbeafe;
+	border-color: #0080ff;
+	color: #0080ff;
+}
+
+.toolbar-select {
+	padding: 4px 8px;
+	font-size: 0.82rem;
+	font-family: inherit;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	color: #374151;
+	line-height: 1.4;
+	outline: none;
+	max-width: 140px;
+}
+
+.toolbar-select--narrow {
+	max-width: 64px;
+	text-align: center;
+}
+
+.toolbar-btn-sm {
+	padding: 4px 7px;
+	font-size: 0.78rem;
+	font-family: inherit;
+	font-weight: 700;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	color: #374151;
+	line-height: 1.4;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+}
+
+.toolbar-btn-sm:hover {
+	background: #e8f0fe;
+	border-color: #0080ff;
+}
+
+.toolbar-select:focus {
+	border-color: #0080ff;
+}
+
+.toolbar-color {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 2px 6px;
+	font-size: 0.82rem;
+	font-weight: 700;
+	color: #374151;
+	background: #fff;
+	border: 1px solid #e5e7eb;
+	border-radius: 4px;
+	cursor: pointer;
+	transition:
+		background 0.12s,
+		border-color 0.12s;
+	line-height: 1.4;
+}
+
+.toolbar-color:hover {
+	background: #e8f0fe;
+	border-color: #0080ff;
+}
+
+.toolbar-color input[type='color'] {
+	width: 18px;
+	height: 18px;
+	padding: 0;
+	border: none;
+	background: none;
+	cursor: pointer;
+}
+
+.toolbar-color--bg {
+	background: #fffde7;
+}
+
+.toolbar-color-icon {
+	background: #ffe066;
+	padding: 0 3px;
+	border-radius: 2px;
+}
+
+.toolbar-sep {
+	width: 1px;
+	background: #e5e7eb;
+	margin: 2px 4px;
+	align-self: stretch;
+}
+
+.rich-editor {
+	min-height: 220px;
+	max-height: 500px;
+	overflow-y: auto;
+	padding: 12px 14px;
+	font-size: 1rem;
+	font-family: inherit;
+	line-height: 1.6;
+	border: 1px solid #d1d5db;
+	border-radius: 0 0 8px 8px;
+	background: #fff;
+	outline: none;
+	transition:
+		border-color 0.15s,
+		box-shadow 0.15s;
+}
+
+.rich-editor:focus {
+	border-color: #0080ff;
+	box-shadow: 0 0 0 3px rgba(0, 128, 255, 0.15);
+}
+
+.rich-editor:empty::before {
+	content: attr(data-placeholder);
+	color: #9ca3af;
+	pointer-events: none;
+}
+
+.rich-editor ul,
+.rich-editor ol {
+	padding-left: 24px;
+	margin: 4px 0;
+}
+
+.rich-editor p {
+	margin: 0 0 4px;
+}
+
+@media (max-width: 599px) {
+	.rich-editor {
+		min-height: 180px;
+		font-size: 1rem;
+	}
+
+	.rich-editor-toolbar button {
+		padding: 6px 10px;
+		min-height: 36px;
+	}
+}

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -799,6 +799,20 @@ body {
 .user-dropdown-item:hover {
 	background: #f3f4f6;
 }
+.user-dropdown-item--loading {
+	color: #9ca3af;
+	font-style: italic;
+	cursor: default;
+}
+.user-dropdown-item .contact-name {
+	display: block;
+	font-weight: 500;
+}
+.user-dropdown-item .contact-email {
+	display: block;
+	font-size: 0.8rem;
+	color: #6b7280;
+}
 
 /* ---- Program timeline (view) ---- */
 .program-timeline {
@@ -1637,7 +1651,7 @@ body {
 	overflow-y: auto;
 	padding: 12px 14px;
 	font-size: 1rem;
-	font-family: inherit;
+	font-family: Arial, Helvetica, sans-serif;
 	line-height: 1.6;
 	border: 1px solid #d1d5db;
 	border-radius: 0 0 8px 8px;
@@ -1646,6 +1660,15 @@ body {
 	transition:
 		border-color 0.15s,
 		box-shadow 0.15s;
+}
+
+.rich-editor--compact {
+	min-height: 80px;
+	max-height: 300px;
+}
+
+.rich-editor-toolbar--compact {
+	flex-wrap: wrap;
 }
 
 .rich-editor:focus {
@@ -1679,4 +1702,188 @@ body {
 		padding: 6px 10px;
 		min-height: 36px;
 	}
+}
+
+/* ─── Mail Warning Dialog ─── */
+.mail-warning-overlay {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+}
+
+.mail-warning-box {
+	background: #fff;
+	border-radius: 16px;
+	box-shadow: 0 8px 40px rgba(0, 0, 0, 0.12);
+	padding: 32px;
+	max-width: 480px;
+	width: 100%;
+	text-align: center;
+}
+
+.mail-warning-icon {
+	font-size: 2.5rem;
+	margin-bottom: 12px;
+}
+
+.mail-warning-title {
+	font-size: 1.2rem;
+	font-weight: 700;
+	color: #1a202c;
+	margin: 0 0 8px;
+}
+
+.mail-warning-text {
+	font-size: 0.95rem;
+	color: #6b7280;
+	line-height: 1.5;
+	margin: 0 0 24px;
+}
+
+.mail-warning-actions {
+	display: flex;
+	justify-content: center;
+	gap: 12px;
+}
+
+/* ─── Sent Mails Section ─── */
+.sent-mails-section {
+	margin-bottom: 24px;
+}
+
+.sent-mails-title {
+	font-size: 1rem;
+	font-weight: 700;
+	color: #1a202c;
+	margin: 0 0 12px;
+}
+
+.sent-mails-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.sent-mail-card {
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: #f9fafb;
+	border: 1px solid #e5e7eb;
+	border-radius: 10px;
+	padding: 12px 16px;
+	cursor: pointer;
+	transition:
+		background 0.15s,
+		border-color 0.15s;
+	font-family: inherit;
+	font-size: inherit;
+	color: inherit;
+}
+
+.sent-mail-card:hover {
+	background: #f0f4ff;
+	border-color: #0080ff;
+}
+
+.sent-mail-card-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 12px;
+	margin-bottom: 4px;
+}
+
+.sent-mail-subject {
+	font-weight: 600;
+	color: #1a202c;
+	font-size: 0.95rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	flex: 1;
+}
+
+.sent-mail-date {
+	font-size: 0.8rem;
+	color: #9ca3af;
+	white-space: nowrap;
+}
+
+.sent-mail-meta {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	font-size: 0.82rem;
+	color: #6b7280;
+}
+
+.sent-mail-meta span {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* ─── Mail Viewer Overlay ─── */
+.mail-viewer-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.45);
+	z-index: 199;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 16px;
+}
+
+.mail-viewer-modal {
+	background: #fff;
+	border-radius: 16px;
+	box-shadow: 0 8px 40px rgba(0, 0, 0, 0.18);
+	width: 100%;
+	max-width: 700px;
+	max-height: 85vh;
+	display: flex;
+	flex-direction: column;
+}
+
+.mail-viewer-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 20px 24px 0;
+}
+
+.mail-viewer-title {
+	font-size: 1.1rem;
+	font-weight: 700;
+	color: #1a202c;
+	margin: 0;
+}
+
+.mail-viewer-meta {
+	padding: 16px 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	font-size: 0.88rem;
+	color: #374151;
+	border-bottom: 1px solid #e5e7eb;
+}
+
+.mail-viewer-body {
+	padding: 20px 24px;
+	overflow-y: auto;
+	flex: 1;
+	font-size: 0.95rem;
+	line-height: 1.6;
+	color: #1a202c;
+}
+
+.mail-viewer-actions {
+	padding: 16px 24px;
+	display: flex;
+	justify-content: flex-end;
+	border-top: 1px solid #e5e7eb;
 }

--- a/frontend/src/components/UserAvatar.vue
+++ b/frontend/src/components/UserAvatar.vue
@@ -25,13 +25,6 @@
 				>
 					Profil bearbeiten
 				</router-link>
-				<router-link
-					class="avatar-dropdown-item"
-					to="/mail-templates"
-					@click="open = false"
-				>
-					Mail-Vorlagen
-				</router-link>
 				<button
 					class="avatar-dropdown-item avatar-dropdown-logout"
 					@click="handleLogout"

--- a/frontend/src/composables/useActivities.ts
+++ b/frontend/src/composables/useActivities.ts
@@ -77,7 +77,7 @@ export function useActivities() {
     } catch { /* non-critical */ }
   }
 
-  async function createActivity(input: ActivityInput): Promise<void> {
+  async function createActivity(input: ActivityInput): Promise<string | null> {
     error.value = null
     try {
       const body: Record<string, unknown> = { ...input }
@@ -87,8 +87,11 @@ export function useActivities() {
         body: JSON.stringify(body),
       })
       if (!res.ok) throw new Error(await res.text())
+      const created = await res.json()
+      return created.id ?? null
     } catch (e) {
       error.value = String(e)
+      return null
     }
   }
 

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -19,7 +19,7 @@ const loginRequest = {
 };
 
 const graphMailScopes = {
-	scopes: ['Mail.Send'],
+	scopes: ['Mail.Send', 'People.Read'],
 };
 
 let msalInstance: PublicClientApplication | null = null;

--- a/frontend/src/composables/useContactSearch.ts
+++ b/frontend/src/composables/useContactSearch.ts
@@ -1,0 +1,79 @@
+import { ref } from 'vue';
+import { getGraphAccessToken } from './useAuth';
+
+export interface Contact {
+	displayName: string;
+	email: string;
+}
+
+export function useContactSearch() {
+	const results = ref<Contact[]>([]);
+	const searching = ref(false);
+
+	let abortController: AbortController | null = null;
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	async function search(query: string) {
+		if (debounceTimer) clearTimeout(debounceTimer);
+		if (abortController) abortController.abort();
+
+		const q = query.trim();
+		if (q.length < 2) {
+			results.value = [];
+			return;
+		}
+
+		debounceTimer = setTimeout(async () => {
+			searching.value = true;
+			abortController = new AbortController();
+
+			try {
+				const token = await getGraphAccessToken();
+				const url =
+					`https://graph.microsoft.com/v1.0/me/people` +
+					`?$search="${encodeURIComponent(q)}"` +
+					`&$top=10` +
+					`&$select=displayName,scoredEmailAddresses`;
+
+				const res = await fetch(url, {
+					headers: { Authorization: `Bearer ${token}` },
+					signal: abortController.signal,
+				});
+
+				if (!res.ok) {
+					results.value = [];
+					return;
+				}
+
+				const data = await res.json();
+				const contacts: Contact[] = [];
+				for (const p of data.value ?? []) {
+					const email = p.scoredEmailAddresses?.[0]?.address as
+						| string
+						| undefined;
+					if (email) {
+						contacts.push({
+							displayName: p.displayName ?? email,
+							email,
+						});
+					}
+				}
+				results.value = contacts;
+			} catch (e) {
+				if ((e as Error).name !== 'AbortError') {
+					results.value = [];
+				}
+			} finally {
+				searching.value = false;
+			}
+		}, 300);
+	}
+
+	function clear() {
+		if (debounceTimer) clearTimeout(debounceTimer);
+		if (abortController) abortController.abort();
+		results.value = [];
+	}
+
+	return { results, searching, search, clear };
+}

--- a/frontend/src/composables/useMailTemplates.ts
+++ b/frontend/src/composables/useMailTemplates.ts
@@ -60,6 +60,7 @@ export function useMailTemplates() {
 		department: Department,
 		subject: string,
 		body: string,
+		recipients: string[] = [],
 	): Promise<MailTemplate | null> {
 		error.value = null;
 		try {
@@ -67,7 +68,7 @@ export function useMailTemplates() {
 				`${BASE}/mail-templates/${encodeURIComponent(department)}`,
 				{
 					method: 'PUT',
-					body: JSON.stringify({ subject, body }),
+					body: JSON.stringify({ subject, body, recipients }),
 				},
 			);
 			if (!res.ok) throw new Error(await res.text());

--- a/frontend/src/composables/useMailTemplates.ts
+++ b/frontend/src/composables/useMailTemplates.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import type { MailTemplate, Department } from '../types';
+import type { MailTemplate, Department, SentMail } from '../types';
 import { getIdToken, getGraphAccessToken } from './useAuth';
 
 const BASE = '/api';
@@ -84,6 +84,7 @@ export function useMailTemplates() {
 		subject: string,
 		bodyHtml: string,
 		fromEmail: string,
+		activityId?: string,
 	): Promise<boolean> {
 		sending.value = true;
 		error.value = null;
@@ -102,6 +103,7 @@ export function useMailTemplates() {
 					body: bodyHtml,
 					from: fromEmail,
 					access_token: graphToken,
+					...(activityId ? { activity_id: activityId } : {}),
 				}),
 			});
 			if (!res.ok) {
@@ -117,6 +119,18 @@ export function useMailTemplates() {
 		}
 	}
 
+	async function fetchSentMails(activityId: string): Promise<SentMail[]> {
+		try {
+			const res = await apiFetch(
+				`${BASE}/activities/${encodeURIComponent(activityId)}/sent-mails`,
+			);
+			if (!res.ok) return [];
+			return (await res.json()) as SentMail[];
+		} catch {
+			return [];
+		}
+	}
+
 	return {
 		templates,
 		loading,
@@ -126,5 +140,6 @@ export function useMailTemplates() {
 		fetchTemplate,
 		saveTemplate,
 		sendMail,
+		fetchSentMails,
 	};
 }

--- a/frontend/src/pages/CreatePage.vue
+++ b/frontend/src/pages/CreatePage.vue
@@ -1,158 +1,41 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useActivities } from '../composables/useActivities'
-import { useUsers } from '../composables/useUsers'
 import { user } from '../composables/useAuth'
-import type { Department, ProgramInput, MaterialItem } from '../types'
 
 const router = useRouter()
-const { createActivity, fetchDepartments, departments, error } = useActivities()
-const { users, fetchUsers } = useUsers()
-
-const isAdmin = computed(() => user.value?.role === 'admin')
-const isPio   = computed(() => user.value?.role === 'Pio')
-
-// Non-admins can only create for their own department or the Leiter department
-// Pio is locked to own dept only
-const availableDepartments = computed(() => {
-  if (isAdmin.value) return departments.value
-  const own = user.value?.department
-  if (isPio.value) return departments.value.filter(d => d === own)
-  return departments.value.filter(d => d === 'Leiter' || d === own)
-})
-
-onMounted(async () => {
-  await Promise.all([fetchDepartments(), fetchUsers()])
-})
+const { createActivity, error } = useActivities()
 
 // ---- Form state ------------------------------------------------------------
-const title          = ref('')
-const date           = ref('')
-const start_time     = ref('')
-const end_time       = ref('')
-const goal           = ref('')
-const location       = ref('')
-const responsible    = ref<string[]>(user.value ? [user.value.display_name] : [])
-const department     = ref<Department | ''>(user.value?.department ?? 'Leiter')
-const material       = ref<MaterialItem[]>([{ name: '', responsible: '' }])
-const needs_siko     = ref(false)
-const sikoFile       = ref<File | null>(null)
-const sikoBase64     = ref<string | null>(null)
-const bad_weather    = ref('')
-const programs       = ref<ProgramInput[]>([])
-const submitting     = ref(false)
-
-// ---- Material --------------------------------------------------------------
-function onMaterialInput(i: number) {
-  const isLast = i === material.value.length - 1
-  if (isLast && material.value[i].name !== '') {
-    material.value.push({ name: '', responsible: '' })
-  }
-}
-function onMaterialBlur(i: number) {
-  const isLast = i === material.value.length - 1
-  if (!isLast && material.value[i].name === '') {
-    material.value.splice(i, 1)
-  }
-}
-
-// ---- Material responsible search -------------------------------------------
-const materialRespSearch = ref<Record<number, string>>({})
-const materialRespDropdown = ref<number | null>(null)
-
-function materialRespFiltered(i: number) {
-  const q = (materialRespSearch.value[i] ?? '').toLowerCase()
-  return users.value.filter(u => q === '' || u.display_name.toLowerCase().includes(q))
-}
-function setMaterialResp(i: number, name: string) {
-  material.value[i].responsible = name
-  materialRespSearch.value[i] = ''
-  materialRespDropdown.value = null
-}
-function clearMaterialResp(i: number) {
-  material.value[i].responsible = ''
-}
-function onMaterialRespBlur(i: number) {
-  setTimeout(() => {
-    materialRespDropdown.value = null
-    delete materialRespSearch.value[i]
-  }, 200)
-}
-
-// ---- Responsible search ----------------------------------------------------
-const responsibleSearch = ref('')
-const showResponsibleDropdown = ref(false)
-
-const filteredResponsibleUsers = computed(() => {
-  const q = responsibleSearch.value.toLowerCase()
-  return users.value.filter(
-    (u) =>
-      !responsible.value.includes(u.display_name) &&
-      (q === '' || u.display_name.toLowerCase().includes(q)),
-  )
-})
-
-function addResponsible(name: string) {
-  if (!responsible.value.includes(name)) {
-    responsible.value.push(name)
-  }
-  responsibleSearch.value = ''
-  showResponsibleDropdown.value = false
-}
-
-function removeResponsible(i: number) {
-  responsible.value.splice(i, 1)
-}
-
-function onResponsibleBlur() {
-  setTimeout(() => {
-    showResponsibleDropdown.value = false
-    responsibleSearch.value = ''
-  }, 200)
-}
-
-// ---- Programs --------------------------------------------------------------
-function addProgram() {
-  programs.value.push({ time: '', title: '', description: '', responsible: responsible.value[0] ?? '' })
-}
-function removeProgram(i: number) { programs.value.splice(i, 1) }
-
-// ---- SiKo file -------------------------------------------------------------
-async function onSikoFileChange(e: Event) {
-  const file = (e.target as HTMLInputElement).files?.[0]
-  if (!file) { sikoFile.value = null; sikoBase64.value = null; return }
-  sikoFile.value = file
-  const buf = await file.arrayBuffer()
-  const bytes = new Uint8Array(buf)
-  let binary = ''
-  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
-  sikoBase64.value = btoa(binary)
-}
+const title      = ref('')
+const date       = ref('')
+const start_time = ref('')
+const end_time   = ref('')
+const submitting = ref(false)
 
 // ---- Submit ----------------------------------------------------------------
 async function submit() {
   submitting.value = true
   error.value = null
 
-  await createActivity({
+  const id = await createActivity({
     title:           title.value.trim(),
     date:            date.value,
     start_time:      start_time.value,
     end_time:        end_time.value,
-    goal:            goal.value.trim(),
-    location:        location.value.trim(),
-    responsible:     responsible.value,
-    department:      department.value || null,
-    material:        material.value.filter(m => m.name.trim()).map(m => ({ name: m.name.trim(), ...(m.responsible?.trim() ? { responsible: m.responsible.trim() } : {}) })),
-    needs_siko:      needs_siko.value,
-    siko_base64:     sikoBase64.value ?? undefined,
-    bad_weather_info: bad_weather.value.trim() || null,
-    programs:        programs.value
+    goal:            '',
+    location:        '',
+    responsible:     user.value ? [user.value.display_name] : [],
+    department:      user.value?.department ?? null,
+    material:        [],
+    needs_siko:      false,
+    bad_weather_info: null,
+    programs:        []
   })
 
   submitting.value = false
-  if (!error.value) router.push('/')
+  if (!error.value && id) router.push(`/activities/${id}`)
 }
 </script>
 
@@ -185,167 +68,6 @@ async function submit() {
         <div class="form-group">
           <label for="end_time">Endzeit</label>
           <input id="end_time" v-model="end_time" type="time" />
-        </div>
-      </div>
-
-      <!-- Ort + Verantwortlich + Abteilung -->
-      <div class="form-row form-row--3">
-        <div class="form-group">
-          <label for="location">Ort</label>
-          <input id="location" v-model="location" type="text" placeholder="Veranstaltungsort" />
-        </div>
-        <div class="form-group user-search-group">
-          <label>Verantwortlich</label>
-          <div class="user-chips" v-if="responsible.length">
-            <span v-for="(name, i) in responsible" :key="name" class="user-chip">
-              {{ name }}
-              <button type="button" class="user-chip-remove" @click="removeResponsible(i)">✕</button>
-            </span>
-          </div>
-          <div class="user-search-wrapper">
-            <input
-              type="text"
-              v-model="responsibleSearch"
-              placeholder="Person suchen…"
-              @focus="showResponsibleDropdown = true"
-              @blur="onResponsibleBlur"
-            />
-            <div v-if="showResponsibleDropdown && filteredResponsibleUsers.length" class="user-dropdown">
-              <div
-                v-for="u in filteredResponsibleUsers"
-                :key="u.id"
-                class="user-dropdown-item"
-                @mousedown.prevent="addResponsible(u.display_name)"
-              >
-                {{ u.display_name }}
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="department">Abteilung</label>
-          <input
-            v-if="isPio"
-            class="form-input form-input--readonly"
-            type="text"
-            :value="user?.department || 'Keine Angabe'"
-            readonly
-          />
-          <select v-else id="department" v-model="department">
-            <option value="">Bitte wählen</option>
-            <option v-for="dep in availableDepartments" :key="dep" :value="dep">{{ dep }}</option>
-          </select>
-        </div>
-      </div>
-
-      <!-- Programmpunkte -->
-      <div class="form-section">
-        <p class="form-section-title">Programmpunkte</p>
-        <div style="display: flex; flex-direction: column; gap: 10px;">
-          <div v-for="(prog, i) in programs" :key="i" class="program-card">
-            <button type="button" class="program-card__remove" @click="removeProgram(i)">✕</button>
-            <div class="program-card__fields">
-              <div class="form-group">
-                <label>Minuten</label>
-                <input
-                  type="number" min="0" placeholder="30"
-                  :value="prog.time"
-                  @input="prog.time = ($event.target as HTMLInputElement).value"
-                />
-              </div>
-              <div class="form-group">
-                <label>Titel</label>
-                <input v-model="prog.title" type="text" placeholder="Titel" />
-              </div>
-              <div class="form-group">
-                <label>Verantwortlich</label>
-                <select v-model="prog.responsible">
-                  <option value="" disabled>Bitte wählen</option>
-                  <option v-for="u in users" :key="u.id" :value="u.display_name">{{ u.display_name }}</option>
-                </select>
-              </div>
-              <div class="form-group program-card__full">
-                <label>Beschreibung</label>
-                <textarea v-model="prog.description" rows="2" placeholder="Beschreibung..." />
-              </div>
-            </div>
-          </div>
-          <button type="button" class="btn-add" @click="addProgram">+ Programmpunkt</button>
-        </div>
-      </div>
-
-      <!-- Material -->
-      <div class="form-section">
-        <p class="form-section-title">Material</p>
-        <div class="material-list">
-          <div v-for="(_, i) in material" :key="i" class="material-row">
-            <input
-              v-model="material[i].name"
-              type="text"
-              placeholder="Material…"
-              class="material-row__name"
-              @input="onMaterialInput(i)"
-              @blur="onMaterialBlur(i)"
-            />
-            <div class="material-row__responsible user-search-wrapper">
-              <template v-if="material[i].responsible">
-                <span class="material-resp-chip">
-                  {{ material[i].responsible }}
-                  <button type="button" class="user-chip-remove" @click="clearMaterialResp(i)">✕</button>
-                </span>
-              </template>
-              <template v-else>
-                <input
-                  type="text"
-                  :value="materialRespSearch[i] ?? ''"
-                  @input="materialRespSearch[i] = ($event.target as HTMLInputElement).value"
-                  placeholder="Verantwortlich (optional)"
-                  @focus="materialRespDropdown = i"
-                  @blur="onMaterialRespBlur(i)"
-                />
-                <div v-if="materialRespDropdown === i && materialRespFiltered(i).length" class="user-dropdown">
-                  <div
-                    v-for="u in materialRespFiltered(i)"
-                    :key="u.id"
-                    class="user-dropdown-item"
-                    @mousedown.prevent="setMaterialResp(i, u.display_name)"
-                  >
-                    {{ u.display_name }}
-                  </div>
-                </div>
-              </template>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- SiKo -->
-      <div class="form-section">
-        <p class="form-section-title">Sicherheitskonzept</p>
-        <label class="form-check">
-          <input type="checkbox" v-model="needs_siko" />
-          <span>Sicherheitskonzept benötigt?</span>
-        </label>
-        <div v-if="needs_siko" style="margin-top: 12px;">
-          <div class="form-group">
-            <label for="siko_file">SiKo (PDF)</label>
-            <input id="siko_file" type="file" accept=".pdf" @change="onSikoFileChange" />
-            <span v-if="sikoFile" class="file-name">{{ sikoFile.name }}</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Ziel + Schlechtwetter -->
-      <div class="form-row">
-        <div class="form-group">
-          <label for="goal">Ziel</label>
-          <textarea id="goal" v-model="goal" rows="3"
-            placeholder="Was soll erreicht werden?" />
-        </div>
-        <div class="form-group">
-          <label for="bad_weather">Schlechtwetter-Info</label>
-          <textarea id="bad_weather" v-model="bad_weather" rows="3"
-            placeholder="Was passiert bei schlechtem Wetter?" />
         </div>
       </div>
 

--- a/frontend/src/pages/DetailPage.vue
+++ b/frontend/src/pages/DetailPage.vue
@@ -269,6 +269,7 @@ function enterEdit() {
 	error.value = null;
 	mode.value = 'edit';
 	startAutoSaveInterval();
+	initProgEditors();
 	nextTick(() => { suppressDirtyTracking = false; dirtyFields.clear(); });
 }
 
@@ -355,6 +356,109 @@ function addProgram() {
 }
 function removeProgram(i: number) {
 	editPrograms.value.splice(i, 1);
+}
+
+// ---- Program description rich editor ----------------------------------------
+const progEditorRefs = ref<Record<number, HTMLElement>>({});
+const progToolbar = ref<{ idx: number; bold: boolean; italic: boolean; underline: boolean; ul: boolean; ol: boolean; font: string; size: string; color: string; bgColor: string } | null>(null);
+
+function setProgEditorRef(el: any, i: number) {
+	if (el) progEditorRefs.value[i] = el as HTMLElement;
+	else delete progEditorRefs.value[i];
+}
+
+function onProgDescInput(i: number) {
+	const el = progEditorRefs.value[i];
+	if (el) editPrograms.value[i].description = el.innerHTML;
+	markDirty(`prog_${i}_desc`);
+	updateProgToolbar(i);
+}
+
+function updateProgToolbar(i: number) {
+	const el = progEditorRefs.value[i];
+	const sel = window.getSelection();
+	if (!sel || !sel.rangeCount || !el) return;
+	const node = sel.anchorNode?.nodeType === 3 ? sel.anchorNode.parentElement : sel.anchorNode as HTMLElement;
+	if (!node || !el.contains(node)) return;
+	const cs = window.getComputedStyle(node);
+	progToolbar.value = {
+		idx: i,
+		bold: document.queryCommandState('bold'),
+		italic: document.queryCommandState('italic'),
+		underline: document.queryCommandState('underline'),
+		ul: document.queryCommandState('insertUnorderedList'),
+		ol: document.queryCommandState('insertOrderedList'),
+		font: cs.fontFamily.replace(/["']/g, '').split(',')[0].trim() || 'Arial',
+		size: parseInt(cs.fontSize).toString() || '12',
+		color: rgbToHex(cs.color) || '#000000',
+		bgColor: (cs.backgroundColor === 'rgba(0, 0, 0, 0)' || cs.backgroundColor === 'transparent') ? '#ffffff' : (rgbToHex(cs.backgroundColor) || '#ffffff'),
+	};
+}
+
+function rgbToHex(rgb: string): string {
+	const m = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+	if (!m) return rgb;
+	return '#' + [m[1], m[2], m[3]].map(x => parseInt(x).toString(16).padStart(2, '0')).join('');
+}
+
+let progSavedSelection: Range | null = null;
+
+function progSaveSelection() {
+	const sel = window.getSelection();
+	const activeIdx = progToolbar.value?.idx;
+	if (activeIdx == null) return;
+	const el = progEditorRefs.value[activeIdx];
+	if (sel?.rangeCount && el?.contains(sel.anchorNode)) {
+		progSavedSelection = sel.getRangeAt(0).cloneRange();
+	}
+}
+
+function progExecCmd(i: number, cmd: string, value?: string) {
+	if (progSavedSelection) {
+		const sel = window.getSelection();
+		if (sel) { sel.removeAllRanges(); sel.addRange(progSavedSelection); }
+		progSavedSelection = null;
+	}
+	document.execCommand(cmd, false, value);
+	progEditorRefs.value[i]?.focus();
+	onProgDescInput(i);
+}
+
+function progSetFontSize(i: number, size: string) {
+	document.execCommand('fontSize', false, '7');
+	const el = progEditorRefs.value[i];
+	const fontEls = el?.querySelectorAll('font[size="7"]');
+	fontEls?.forEach(fe => {
+		const span = document.createElement('span');
+		span.style.fontSize = size + 'px';
+		span.innerHTML = fe.innerHTML;
+		fe.replaceWith(span);
+	});
+	el?.focus();
+	onProgDescInput(i);
+}
+
+function progAdjustFontSize(i: number, delta: number) {
+	const current = parseInt(progToolbar.value?.size ?? '12') || 12;
+	const newSize = Math.max(8, Math.min(72, current + delta));
+	progSetFontSize(i, String(newSize));
+	if (progToolbar.value) progToolbar.value.size = String(newSize);
+}
+
+function onProgEditorFocus(i: number) {
+	progToolbar.value = { idx: i, bold: false, italic: false, underline: false, ul: false, ol: false, font: 'Arial', size: '12', color: '#000000', bgColor: '#ffffff' };
+	updateProgToolbar(i);
+}
+
+function initProgEditors() {
+	nextTick(() => {
+		for (let i = 0; i < editPrograms.value.length; i++) {
+			const el = progEditorRefs.value[i];
+			if (el && el.innerHTML !== editPrograms.value[i].description) {
+				el.innerHTML = editPrograms.value[i].description;
+			}
+		}
+	});
 }
 
 // ---- SiKo file change ------------------------------------------------------
@@ -563,8 +667,7 @@ async function doDelete() {
 									prog.responsible
 								}}</span>
 							</div>
-							<p v-if="prog.description" class="program-desc">
-								{{ prog.description }}
+							<p v-if="prog.description" class="program-desc" v-html="prog.description">
 							</p>
 						</div>
 					</div>
@@ -813,13 +916,47 @@ async function doDelete() {
 							<div class="form-group program-card__full">
 								<label>Beschreibung</label>
 								<div class="input-save-wrap">
-									<textarea
-										v-model="prog.description"
-										rows="2"
-										placeholder="Beschreibung…"
-										:disabled="isLockedByOther(`program_${i}`)"
-										@input="markDirty(`prog_${i}_desc`)"
-									/>
+									<div class="rich-editor-toolbar rich-editor-toolbar--compact" v-if="progToolbar && progToolbar.idx === i">
+										<select class="toolbar-select" :value="progToolbar.font" @change="progExecCmd(i, 'fontName', ($event.target as HTMLSelectElement).value)" title="Schriftart">
+											<option value="Arial" style="font-family:Arial">Arial</option>
+											<option value="Helvetica" style="font-family:Helvetica">Helvetica</option>
+											<option value="Georgia" style="font-family:Georgia">Georgia</option>
+											<option value="Times New Roman" style="font-family:'Times New Roman'">Times New Roman</option>
+											<option value="Courier New" style="font-family:'Courier New'">Courier New</option>
+											<option value="Verdana" style="font-family:Verdana">Verdana</option>
+										</select>
+										<input type="text" class="toolbar-select toolbar-select--narrow" :value="progToolbar.size" @change="progSetFontSize(i, ($event.target as HTMLInputElement).value)" @keydown.enter.prevent="progSetFontSize(i, ($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+										<button type="button" class="toolbar-btn-sm" @click="progAdjustFontSize(i, -2)" title="Kleiner">A−</button>
+										<button type="button" class="toolbar-btn-sm" @click="progAdjustFontSize(i, 2)" title="Grösser">A+</button>
+										<span class="toolbar-sep"></span>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.bold}" @click="progExecCmd(i, 'bold')" title="Fett"><b>B</b></button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.italic}" @click="progExecCmd(i, 'italic')" title="Kursiv"><i>I</i></button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.underline}" @click="progExecCmd(i, 'underline')" title="Unterstrichen"><u>U</u></button>
+										<span class="toolbar-sep"></span>
+										<label class="toolbar-color" title="Schriftfarbe" @mousedown="progSaveSelection">
+											A
+											<input type="color" :value="progToolbar.color" @input="progExecCmd(i, 'foreColor', ($event.target as HTMLInputElement).value)" />
+										</label>
+										<label class="toolbar-color toolbar-color--bg" title="Hintergrundfarbe" @mousedown="progSaveSelection">
+											<span class="toolbar-color-icon">A</span>
+											<input type="color" :value="progToolbar.bgColor" @input="progExecCmd(i, 'hiliteColor', ($event.target as HTMLInputElement).value)" />
+										</label>
+										<span class="toolbar-sep"></span>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.ul}" @click="progExecCmd(i, 'insertUnorderedList')" title="Aufzählung">• Liste</button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.ol}" @click="progExecCmd(i, 'insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+										<span class="toolbar-sep"></span>
+										<button type="button" @click="progExecCmd(i, 'removeFormat')" title="Formatierung entfernen">✕ Format</button>
+									</div>
+									<div
+										:ref="(el) => setProgEditorRef(el, i)"
+										class="rich-editor rich-editor--compact"
+										:contenteditable="!isLockedByOther(`program_${i}`)"
+										@input="onProgDescInput(i)"
+										@focus="onProgEditorFocus(i)"
+										@mouseup="updateProgToolbar(i)"
+										@keyup="updateProgToolbar(i)"
+										data-placeholder="Beschreibung…"
+									></div>
 									<span v-if="savedFields[`prog_${i}_desc`]" class="field-saved-icon field-saved-icon--textarea" :key="savedFields[`prog_${i}_desc`]">💾</span>
 								</div>
 							</div>

--- a/frontend/src/pages/DetailPage.vue
+++ b/frontend/src/pages/DetailPage.vue
@@ -215,13 +215,15 @@ watch(lastUpdatedActivity, (updated) => {
 			editBadWeather.value = updated.bad_weather_info ?? '';
 		if (JSON.stringify(updated.material) !== JSON.stringify(prev.material))
 			editMaterial.value = [...updated.material.map(m => ({ name: m.name, responsible: m.responsible ?? '' })), { name: '', responsible: '' }];
-		if (JSON.stringify(updated.programs) !== JSON.stringify(prev.programs))
+		if (JSON.stringify(updated.programs) !== JSON.stringify(prev.programs)) {
 			editPrograms.value = updated.programs.map((p) => ({
 				time: p.time,
 				title: p.title,
 				description: p.description,
 				responsible: p.responsible,
 			}));
+			initProgEditors();
+		}
 		nextTick(() => {
 			applyingRemote = false;
 		}); // reset after Vue has flushed all watchers

--- a/frontend/src/pages/MailComposerPage.vue
+++ b/frontend/src/pages/MailComposerPage.vue
@@ -3,15 +3,16 @@ import { ref, onMounted, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useActivities } from '../composables/useActivities';
 import { useMailTemplates } from '../composables/useMailTemplates';
+import { useContactSearch } from '../composables/useContactSearch';
 import { user } from '../composables/useAuth';
-import type { Activity, Department } from '../types';
+import type { Activity, Department, SentMail } from '../types';
 
 const route = useRoute()
 const router = useRouter()
 const activityId = route.params.id as string
 
 const { fetchActivity } = useActivities()
-const { fetchTemplate, sendMail, sending, error } = useMailTemplates()
+const { fetchTemplate, sendMail, sending, error, fetchSentMails } = useMailTemplates()
 
 const activity = ref<Activity | null>(null)
 const subject = ref('')
@@ -30,6 +31,12 @@ const curUl = ref(false)
 const curOl = ref(false)
 const curBgColor = ref('#ffffff')
 let savedSelection: Range | null = null
+
+// Sent mail state
+const sentMails = ref<SentMail[]>([])
+const showWarning = ref(false)
+const warningConfirmed = ref(false)
+const viewingMail = ref<SentMail | null>(null)
 
 function formatDateLong(d: string): string {
   return new Date(d + 'T00:00:00').toLocaleDateString('de-DE', {
@@ -94,6 +101,12 @@ onMounted(async () => {
     return
   }
   activity.value = act
+
+  // Load sent mails for this activity
+  sentMails.value = await fetchSentMails(activityId)
+  if (sentMails.value.length > 0) {
+    showWarning.value = true
+  }
 
   if (act.department) {
     const tpl = await fetchTemplate(act.department as Department)
@@ -245,12 +258,47 @@ function adjustFontSize(delta: number) {
   curSize.value = String(newSize)
 }
 
-function addRecipient() {
-	recipients.value.push('');
+function addRecipient(email: string) {
+	if (!recipients.value.includes(email)) {
+		if (recipients.value.length === 1 && recipients.value[0] === '') {
+			recipients.value[0] = email;
+		} else {
+			recipients.value.push(email);
+		}
+	}
+	recipientSearch.value = '';
+	showRecipientDropdown.value = false;
+	clearContactSearch();
 }
 
 function removeRecipient(index: number) {
 	recipients.value.splice(index, 1);
+	if (recipients.value.length === 0) recipients.value = [''];
+}
+
+// ---- Contact search ---------------------------------------------------------
+const { results: contactResults, searching: contactSearching, search: searchContacts, clear: clearContactSearch } = useContactSearch()
+const recipientSearch = ref('')
+const showRecipientDropdown = ref(false)
+
+function onRecipientSearchInput() {
+	searchContacts(recipientSearch.value)
+}
+
+function onRecipientBlur() {
+	setTimeout(() => {
+		showRecipientDropdown.value = false
+	}, 200)
+}
+
+function onRecipientKeydown(e: KeyboardEvent) {
+	if (e.key === 'Enter') {
+		e.preventDefault()
+		const val = recipientSearch.value.trim()
+		if (val && val.includes('@')) {
+			addRecipient(val)
+		}
+	}
 }
 
 async function handleSend() {
@@ -261,8 +309,26 @@ async function handleSend() {
 	const fromEmail = user.value?.email ?? '';
 	const bodyHtml = body.value;
 
-	const ok = await sendMail(validTo, subject.value, bodyHtml, fromEmail);
+	const ok = await sendMail(validTo, subject.value, bodyHtml, fromEmail, activityId);
 	if (ok) sent.value = true;
+}
+
+function confirmWarning() {
+	warningConfirmed.value = true
+	showWarning.value = false
+}
+
+function formatSentDate(iso: string): string {
+	const d = new Date(iso)
+	return d.toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function openMailViewer(mail: SentMail) {
+	viewingMail.value = mail
+}
+
+function closeMailViewer() {
+	viewingMail.value = null
 }
 </script>
 
@@ -275,6 +341,22 @@ async function handleSend() {
 	<main class="main">
 		<p v-if="loadError" class="error">{{ loadError }}</p>
 
+		<!-- Warning dialog when mails already sent -->
+		<div v-else-if="showWarning && !warningConfirmed" class="mail-warning-overlay">
+			<div class="mail-warning-box">
+				<div class="mail-warning-icon">⚠️</div>
+				<h2 class="mail-warning-title">Bereits versendete Mails</h2>
+				<p class="mail-warning-text">
+					Für diese Aktivität {{ sentMails.length === 1 ? 'wurde bereits 1 Mail' : `wurden bereits ${sentMails.length} Mails` }} versendet.
+					Möchtest du trotzdem ein weiteres Mail senden?
+				</p>
+				<div class="mail-warning-actions">
+					<button class="btn-secondary" @click="router.back()">Abbrechen</button>
+					<button class="btn-primary" @click="confirmWarning">Trotzdem senden</button>
+				</div>
+			</div>
+		</div>
+
 		<div v-else-if="sent" class="mail-sent">
 			<p class="mail-sent-text">✅ Mail wurde erfolgreich versendet!</p>
 			<button class="btn-primary" @click="router.back()">
@@ -282,7 +364,53 @@ async function handleSend() {
 			</button>
 		</div>
 
-		<form v-else-if="activity" class="detail-form" @submit.prevent="handleSend">
+		<template v-else-if="activity">
+			<!-- Sent mails list -->
+			<div v-if="sentMails.length > 0" class="sent-mails-section">
+				<h2 class="sent-mails-title">Bereits versendete Mails</h2>
+				<div class="sent-mails-list">
+					<button
+						v-for="mail in sentMails"
+						:key="mail.id"
+						class="sent-mail-card"
+						@click="openMailViewer(mail)"
+					>
+						<div class="sent-mail-card-header">
+							<span class="sent-mail-subject">{{ mail.subject }}</span>
+							<span class="sent-mail-date">{{ formatSentDate(mail.sent_at) }}</span>
+						</div>
+						<div class="sent-mail-meta">
+							<span class="sent-mail-from">Von: {{ mail.sender_email }}</span>
+							<span class="sent-mail-to">An: {{ mail.to_emails.join(', ') }}</span>
+						</div>
+					</button>
+				</div>
+			</div>
+
+			<!-- Mail viewer overlay -->
+			<Teleport to="body">
+				<div v-if="viewingMail" class="mail-viewer-overlay" @click.self="closeMailViewer">
+					<div class="mail-viewer-modal">
+						<div class="mail-viewer-header">
+							<h2 class="mail-viewer-title">Versendetes Mail</h2>
+							<button class="bug-close-btn" @click="closeMailViewer" aria-label="Schliessen">×</button>
+						</div>
+						<div class="mail-viewer-meta">
+							<div><strong>Von:</strong> {{ viewingMail.sender_email }}</div>
+							<div><strong>An:</strong> {{ viewingMail.to_emails.join(', ') }}</div>
+							<div><strong>Betreff:</strong> {{ viewingMail.subject }}</div>
+							<div><strong>Gesendet:</strong> {{ formatSentDate(viewingMail.sent_at) }}</div>
+						</div>
+						<div class="mail-viewer-body" v-html="viewingMail.body_html"></div>
+						<div class="mail-viewer-actions">
+							<button class="btn-secondary" @click="closeMailViewer">Schliessen</button>
+						</div>
+					</div>
+				</div>
+			</Teleport>
+
+			<!-- Compose form -->
+			<form class="detail-form" @submit.prevent="handleSend">
 			<!-- Activity info -->
 			<div class="mail-activity-info">
 				<span class="card-dept-badge" v-if="activity.department">{{
@@ -303,28 +431,36 @@ async function handleSend() {
 			</div>
 
 			<!-- Recipients -->
-			<div class="form-group">
+			<div class="form-group user-search-group">
 				<label>Empfänger <span class="required">*</span></label>
-				<div class="mail-recipients">
-					<div v-for="(_, i) in recipients" :key="i" class="mail-recipient-row">
-						<input
-							v-model="recipients[i]"
-							type="email"
-							placeholder="email@example.com"
-							required
-						/>
-						<button
-							v-if="recipients.length > 1"
-							type="button"
-							class="btn-remove-sm"
-							@click="removeRecipient(i)"
+				<div class="user-chips" v-if="recipients.filter(r => r).length">
+					<span v-for="(email, i) in recipients" :key="email || i" class="user-chip" v-show="email">
+						{{ email }}
+						<button type="button" class="user-chip-remove" @click="removeRecipient(i)">✕</button>
+					</span>
+				</div>
+				<div class="user-search-wrapper">
+					<input
+						type="text"
+						v-model="recipientSearch"
+						placeholder="Kontakt suchen…"
+						@input="onRecipientSearchInput"
+						@focus="showRecipientDropdown = true"
+						@blur="onRecipientBlur"
+						@keydown="onRecipientKeydown"
+					/>
+					<div v-if="showRecipientDropdown && (contactResults.length || contactSearching)" class="user-dropdown">
+						<div v-if="contactSearching" class="user-dropdown-item user-dropdown-item--loading">Suchen…</div>
+						<div
+							v-for="c in contactResults"
+							:key="c.email"
+							class="user-dropdown-item"
+							@mousedown.prevent="addRecipient(c.email)"
 						>
-							×
-						</button>
+							<span class="contact-name">{{ c.displayName }}</span>
+							<span class="contact-email">{{ c.email }}</span>
+						</div>
 					</div>
-					<button type="button" class="btn-add" @click="addRecipient">
-						+ Empfänger
-					</button>
 				</div>
 			</div>
 
@@ -392,6 +528,7 @@ async function handleSend() {
 				</button>
 			</div>
 		</form>
+		</template>
 
 		<p v-else class="loading">Laden...</p>
 	</main>

--- a/frontend/src/pages/MailComposerPage.vue
+++ b/frontend/src/pages/MailComposerPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useActivities } from '../composables/useActivities';
 import { useMailTemplates } from '../composables/useMailTemplates';
@@ -19,10 +19,27 @@ const body = ref('')
 const recipients = ref<string[]>([''])
 const sent = ref(false)
 const loadError = ref<string | null>(null)
+const editorRef = ref<HTMLElement | null>(null)
+const curFont = ref('Arial')
+const curSize = ref('12')
+const curColor = ref('#000000')
+const curBold = ref(false)
+const curItalic = ref(false)
+const curUnderline = ref(false)
+const curUl = ref(false)
+const curOl = ref(false)
+const curBgColor = ref('#ffffff')
+let savedSelection: Range | null = null
 
 function formatDateLong(d: string): string {
   return new Date(d + 'T00:00:00').toLocaleDateString('de-DE', {
     weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'
+  })
+}
+
+function formatDateShort(d: string): string {
+  return new Date(d + 'T00:00:00').toLocaleDateString('de-DE', {
+    day: '2-digit', month: '2-digit', year: 'numeric'
   })
 }
 
@@ -34,18 +51,40 @@ function formatPrograms(act: Activity): string {
 }
 
 function replaceTemplateVars(text: string, act: Activity): string {
-  return text
-    .replace(/\{\{titel\}\}/gi,            act.title)
-    .replace(/\{\{datum\}\}/gi,            formatDateLong(act.date))
-    .replace(/\{\{startzeit\}\}/gi,        act.start_time)
-    .replace(/\{\{endzeit\}\}/gi,          act.end_time)
-    .replace(/\{\{ort\}\}/gi,              act.location)
-    .replace(/\{\{verantwortlich\}\}/gi,   act.responsible.join(', '))
-    .replace(/\{\{abteilung\}\}/gi,        act.department ?? '—')
-    .replace(/\{\{ziel\}\}/gi,             act.goal)
-    .replace(/\{\{material\}\}/gi,         act.material.map(m => m.name).join(', ') || '—')
-    .replace(/\{\{schlechtwetter\}\}/gi,   act.bad_weather_info ?? '—')
-    .replace(/\{\{programm\}\}/gi,         formatPrograms(act))
+  // Use a temporary DOM element to do replacements while preserving formatting.
+  // Walking text nodes means <font face="Arial">{{titel}}</font> keeps its font.
+  const container = document.createElement('div')
+  container.innerHTML = text
+  const senderEmail = user.value?.email ?? ''
+  const senderName = user.value?.display_name ?? ''
+  const vars: Record<string, string> = {
+    titel: act.title,
+    datum: formatDateLong(act.date),
+    datum_kurz: formatDateShort(act.date),
+    startzeit: act.start_time,
+    endzeit: act.end_time,
+    ort: act.location,
+    verantwortlich: act.responsible.join(', '),
+    abteilung: act.department ?? '—',
+    ziel: act.goal,
+    material: act.material.map(m => m.name).join(', ') || '—',
+    schlechtwetter: act.bad_weather_info ?? '—',
+    programm: formatPrograms(act),
+    absender_email: senderEmail,
+    absender_name: senderName,
+  }
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+  const textNodes: Text[] = []
+  while (walker.nextNode()) textNodes.push(walker.currentNode as Text)
+  for (const node of textNodes) {
+    const original = node.nodeValue ?? ''
+    const replaced = original.replace(/\{\{(\w+)\}\}/gi, (m, key) => {
+      const lk = key.toLowerCase()
+      return lk in vars ? vars[lk] : m
+    })
+    if (replaced !== original) node.nodeValue = replaced
+  }
+  return container.innerHTML
 }
 
 onMounted(async () => {
@@ -61,9 +100,150 @@ onMounted(async () => {
     if (tpl) {
       subject.value = replaceTemplateVars(tpl.subject, act)
       body.value    = replaceTemplateVars(tpl.body, act)
+      if (tpl.recipients?.length) {
+        recipients.value = [...tpl.recipients]
+      }
     }
   }
+  nextTick(() => {
+    if (editorRef.value) editorRef.value.innerHTML = body.value
+  })
 })
+
+function onEditorInput() {
+  if (editorRef.value) body.value = editorRef.value.innerHTML
+  updateToolbarState()
+}
+
+function updateToolbarState() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const node = sel.anchorNode?.nodeType === 3 ? sel.anchorNode.parentElement : sel.anchorNode as HTMLElement
+  if (!node || !editorRef.value.contains(node)) return
+  const cs = window.getComputedStyle(node)
+  curFont.value = cs.fontFamily.replace(/["']/g, '').split(',')[0].trim() || 'Arial'
+  curSize.value = parseInt(cs.fontSize).toString() || '12'
+  curColor.value = rgbToHex(cs.color) || '#000000'
+  const bgRaw = cs.backgroundColor
+  curBgColor.value = (bgRaw === 'rgba(0, 0, 0, 0)' || bgRaw === 'transparent') ? '#ffffff' : (rgbToHex(bgRaw) || '#ffffff')
+  curBold.value = document.queryCommandState('bold')
+  curItalic.value = document.queryCommandState('italic')
+  curUnderline.value = document.queryCommandState('underline')
+  curUl.value = document.queryCommandState('insertUnorderedList')
+  curOl.value = document.queryCommandState('insertOrderedList')
+}
+
+function rgbToHex(rgb: string): string {
+  const m = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/)
+  if (!m) return rgb
+  return '#' + [m[1], m[2], m[3]].map(x => parseInt(x).toString(16).padStart(2, '0')).join('')
+}
+
+function expandSelectionToVariables() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const range = sel.getRangeAt(0)
+  const container = editorRef.value
+  const fullText = container.textContent ?? ''
+  function nodeOffset(node: Node, off: number): number {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      if (walker.currentNode === node) return pos + off
+      pos += (walker.currentNode as Text).length
+    }
+    return pos
+  }
+  function offsetToNodePos(target: number): { node: Text; offset: number } | null {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      const t = walker.currentNode as Text
+      if (pos + t.length >= target) return { node: t, offset: target - pos }
+      pos += t.length
+    }
+    return null
+  }
+  let startOff = nodeOffset(range.startContainer, range.startOffset)
+  let endOff = nodeOffset(range.endContainer, range.endOffset)
+  const varPattern = /\{\{\w+\}\}/g
+  let m: RegExpExecArray | null
+  while ((m = varPattern.exec(fullText)) !== null) {
+    const vs = m.index, ve = m.index + m[0].length
+    if (startOff > vs && startOff < ve) startOff = vs
+    if (endOff > vs && endOff < ve) endOff = ve
+  }
+  const newStart = offsetToNodePos(startOff)
+  const newEnd = offsetToNodePos(endOff)
+  if (newStart && newEnd) {
+    range.setStart(newStart.node, newStart.offset)
+    range.setEnd(newEnd.node, newEnd.offset)
+    sel.removeAllRanges()
+    sel.addRange(range)
+  }
+}
+
+function execCmd(cmd: string, value?: string) {
+  if (savedSelection) {
+    const sel = window.getSelection()
+    if (sel) { sel.removeAllRanges(); sel.addRange(savedSelection) }
+    savedSelection = null
+  }
+  expandSelectionToVariables()
+  document.execCommand(cmd, false, value)
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function saveSelection() {
+  const sel = window.getSelection()
+  if (sel?.rangeCount && editorRef.value?.contains(sel.anchorNode)) {
+    savedSelection = sel.getRangeAt(0).cloneRange()
+  }
+}
+
+function setFontSize(size: string) {
+  expandSelectionToVariables()
+  document.execCommand('fontSize', false, '7')
+  const fontEls = editorRef.value?.querySelectorAll('font[size="7"]')
+  const newSpans: HTMLElement[] = []
+  fontEls?.forEach(el => {
+    const span = document.createElement('span')
+    span.style.fontSize = size + 'px'
+    span.innerHTML = el.innerHTML
+    el.replaceWith(span)
+    newSpans.push(span)
+  })
+  if (newSpans.length) {
+    const sel = window.getSelection()
+    if (sel) {
+      const range = document.createRange()
+      const tw1 = document.createTreeWalker(newSpans[0], NodeFilter.SHOW_TEXT)
+      const firstText = tw1.nextNode()
+      const lastSpan = newSpans[newSpans.length - 1]
+      const tw2 = document.createTreeWalker(lastSpan, NodeFilter.SHOW_TEXT)
+      let lastText: Node | null = null
+      while (tw2.nextNode()) lastText = tw2.currentNode
+      if (firstText && lastText) {
+        range.setStart(firstText, 0)
+        range.setEnd(lastText, (lastText as Text).length)
+        sel.removeAllRanges()
+        sel.addRange(range)
+      }
+    }
+  }
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function adjustFontSize(delta: number) {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const current = parseInt(curSize.value) || 12
+  const newSize = Math.max(8, Math.min(72, current + delta))
+  setFontSize(String(newSize))
+  curSize.value = String(newSize)
+}
 
 function addRecipient() {
 	recipients.value.push('');
@@ -79,7 +259,7 @@ async function handleSend() {
 		return;
 
 	const fromEmail = user.value?.email ?? '';
-	const bodyHtml = body.value.replace(/\n/g, '<br>');
+	const bodyHtml = body.value;
 
 	const ok = await sendMail(validTo, subject.value, bodyHtml, fromEmail);
 	if (ok) sent.value = true;
@@ -157,7 +337,48 @@ async function handleSend() {
 			<!-- Body -->
 			<div class="form-group">
 				<label>Nachricht <span class="required">*</span></label>
-				<textarea v-model="body" rows="12" required></textarea>
+				<div class="rich-editor-toolbar">
+					<select class="toolbar-select" :value="curFont" @change="execCmd('fontName', ($event.target as HTMLSelectElement).value)" title="Schriftart">
+						<option value="" disabled>Schriftart</option>
+						<option value="Arial" style="font-family:Arial">Arial</option>
+						<option value="Helvetica" style="font-family:Helvetica">Helvetica</option>
+						<option value="Georgia" style="font-family:Georgia">Georgia</option>
+						<option value="Times New Roman" style="font-family:'Times New Roman'">Times New Roman</option>
+						<option value="Courier New" style="font-family:'Courier New'">Courier New</option>
+						<option value="Verdana" style="font-family:Verdana">Verdana</option>
+						<option value="Trebuchet MS" style="font-family:'Trebuchet MS'">Trebuchet MS</option>
+					</select>
+					<input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+					<button type="button" class="toolbar-btn-sm" @click="adjustFontSize(-2)" title="Kleiner">A−</button>
+					<button type="button" class="toolbar-btn-sm" @click="adjustFontSize(2)" title="Grösser">A+</button>
+					<span class="toolbar-sep"></span>
+					<button type="button" :class="{'toolbar-btn--active': curBold}" @click="execCmd('bold')" title="Fett"><b>B</b></button>
+					<button type="button" :class="{'toolbar-btn--active': curItalic}" @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
+					<button type="button" :class="{'toolbar-btn--active': curUnderline}" @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
+					<span class="toolbar-sep"></span>
+					<label class="toolbar-color" title="Schriftfarbe" @mousedown="saveSelection">
+						A
+						<input type="color" :value="curColor" @input="execCmd('foreColor', ($event.target as HTMLInputElement).value)" />
+					</label>
+					<label class="toolbar-color toolbar-color--bg" title="Hintergrundfarbe" @mousedown="saveSelection">
+						<span class="toolbar-color-icon">A</span>
+						<input type="color" :value="curBgColor" @input="execCmd('hiliteColor', ($event.target as HTMLInputElement).value)" />
+					</label>
+					<span class="toolbar-sep"></span>
+					<button type="button" :class="{'toolbar-btn--active': curUl}" @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
+					<button type="button" :class="{'toolbar-btn--active': curOl}" @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+					<span class="toolbar-sep"></span>
+					<button type="button" @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
+				</div>
+				<div
+					ref="editorRef"
+					class="rich-editor"
+					contenteditable="true"
+					@input="onEditorInput"
+					@mouseup="updateToolbarState"
+					@keyup="updateToolbarState"
+					data-placeholder="Nachricht…"
+				></div>
 			</div>
 
 			<p v-if="error" class="error">{{ error }}</p>

--- a/frontend/src/pages/MailTemplatePage.vue
+++ b/frontend/src/pages/MailTemplatePage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, nextTick } from 'vue'
 import { useMailTemplates } from '../composables/useMailTemplates'
 import { user } from '../composables/useAuth'
 import type { Department } from '../types'
@@ -8,7 +8,8 @@ const ALL_DEPARTMENTS: Department[] = ['Leiter', 'Pio', 'Pfadi', 'Wölfe', 'Bibe
 
 const TEMPLATE_VARIABLES = [
   { var: '{{titel}}',            desc: 'Titel der Aktivität' },
-  { var: '{{datum}}',            desc: 'Datum (z.B. Samstag, 12. April 2026)' },
+  { var: '{{datum}}',            desc: 'Datum lang (z.B. Samstag, 12. April 2026)' },
+  { var: '{{datum_kurz}}',       desc: 'Datum kurz (z.B. 12.04.2026)' },
   { var: '{{startzeit}}',        desc: 'Startzeit (HH:MM)' },
   { var: '{{endzeit}}',          desc: 'Endzeit (HH:MM)' },
   { var: '{{ort}}',              desc: 'Veranstaltungsort' },
@@ -18,6 +19,8 @@ const TEMPLATE_VARIABLES = [
   { var: '{{material}}',         desc: 'Materialliste (kommagetrennt)' },
   { var: '{{schlechtwetter}}',   desc: 'Schlechtwetter-Info' },
   { var: '{{programm}}',         desc: 'Programmpunkte (formatiert)' },
+  { var: '{{absender_email}}',   desc: 'E-Mail-Adresse des Absenders' },
+  { var: '{{absender_name}}',    desc: 'Voller Name des Absenders (z.B. Leandro Klaus v/o Topo)' },
 ]
 
 const { fetchTemplates, saveTemplate, templates, loading, error } = useMailTemplates()
@@ -25,7 +28,6 @@ const { fetchTemplates, saveTemplate, templates, loading, error } = useMailTempl
 const isAdmin        = computed(() => user.value?.role === 'admin')
 const isStufenleiter = computed(() => user.value?.role === 'Stufenleiter')
 
-// Stufenleiter sees only own dept; admin sees all
 const visibleDepartments = computed<Department[]>(() => {
   if (isStufenleiter.value) {
     const own = user.value?.department as Department | undefined
@@ -34,7 +36,6 @@ const visibleDepartments = computed<Department[]>(() => {
   return ALL_DEPARTMENTS
 })
 
-// Default: own dept for Stufenleiter, first dept otherwise
 const activeDept = ref<Department>(
   isStufenleiter.value && user.value?.department
     ? user.value.department as Department
@@ -43,9 +44,21 @@ const activeDept = ref<Department>(
 
 const subject = ref('')
 const body = ref('')
+const recipients = ref<string[]>([''])
 const saving = ref(false)
 const saved = ref(false)
 const showVars = ref(false)
+const editorRef = ref<HTMLElement | null>(null)
+const curFont = ref('Arial')
+const curSize = ref('12')
+const curColor = ref('#000000')
+const curBold = ref(false)
+const curItalic = ref(false)
+const curUnderline = ref(false)
+const curUl = ref(false)
+const curOl = ref(false)
+const curBgColor = ref('#ffffff')
+let savedSelection: Range | null = null
 
 onMounted(async () => {
   await fetchTemplates()
@@ -58,12 +71,162 @@ function loadDept(dept: Department) {
   const tpl = templates.value.find(t => t.department === dept)
   subject.value = tpl?.subject ?? ''
   body.value    = tpl?.body ?? ''
+  recipients.value = tpl?.recipients?.length ? [...tpl.recipients] : ['']
+  nextTick(() => {
+    if (editorRef.value) editorRef.value.innerHTML = body.value
+  })
+}
+
+function onEditorInput() {
+  if (editorRef.value) body.value = editorRef.value.innerHTML
+  updateToolbarState()
+}
+
+function updateToolbarState() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const node = sel.anchorNode?.nodeType === 3 ? sel.anchorNode.parentElement : sel.anchorNode as HTMLElement
+  if (!node || !editorRef.value.contains(node)) return
+  const cs = window.getComputedStyle(node)
+  curFont.value = cs.fontFamily.replace(/["']/g, '').split(',')[0].trim() || 'Arial'
+  curSize.value = parseInt(cs.fontSize).toString() || '12'
+  curColor.value = rgbToHex(cs.color) || '#000000'
+  const bgRaw = cs.backgroundColor
+  curBgColor.value = (bgRaw === 'rgba(0, 0, 0, 0)' || bgRaw === 'transparent') ? '#ffffff' : (rgbToHex(bgRaw) || '#ffffff')
+  curBold.value = document.queryCommandState('bold')
+  curItalic.value = document.queryCommandState('italic')
+  curUnderline.value = document.queryCommandState('underline')
+  curUl.value = document.queryCommandState('insertUnorderedList')
+  curOl.value = document.queryCommandState('insertOrderedList')
+}
+
+function rgbToHex(rgb: string): string {
+  const m = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/)
+  if (!m) return rgb
+  return '#' + [m[1], m[2], m[3]].map(x => parseInt(x).toString(16).padStart(2, '0')).join('')
+}
+
+function expandSelectionToVariables() {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const range = sel.getRangeAt(0)
+  const container = editorRef.value
+  const fullText = container.textContent ?? ''
+  // Map range start/end to text offsets, then expand if inside a {{...}}
+  function nodeOffset(node: Node, off: number): number {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      if (walker.currentNode === node) return pos + off
+      pos += (walker.currentNode as Text).length
+    }
+    return pos
+  }
+  function offsetToNodePos(target: number): { node: Text; offset: number } | null {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let pos = 0
+    while (walker.nextNode()) {
+      const t = walker.currentNode as Text
+      if (pos + t.length >= target) return { node: t, offset: target - pos }
+      pos += t.length
+    }
+    return null
+  }
+  let startOff = nodeOffset(range.startContainer, range.startOffset)
+  let endOff = nodeOffset(range.endContainer, range.endOffset)
+  // Expand start backwards if inside a variable
+  const varPattern = /\{\{\w+\}\}/g
+  let m: RegExpExecArray | null
+  while ((m = varPattern.exec(fullText)) !== null) {
+    const vs = m.index, ve = m.index + m[0].length
+    if (startOff > vs && startOff < ve) startOff = vs
+    if (endOff > vs && endOff < ve) endOff = ve
+  }
+  const newStart = offsetToNodePos(startOff)
+  const newEnd = offsetToNodePos(endOff)
+  if (newStart && newEnd) {
+    range.setStart(newStart.node, newStart.offset)
+    range.setEnd(newEnd.node, newEnd.offset)
+    sel.removeAllRanges()
+    sel.addRange(range)
+  }
+}
+
+function execCmd(cmd: string, value?: string) {
+  if (savedSelection) {
+    const sel = window.getSelection()
+    if (sel) { sel.removeAllRanges(); sel.addRange(savedSelection) }
+    savedSelection = null
+  }
+  expandSelectionToVariables()
+  document.execCommand(cmd, false, value)
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function saveSelection() {
+  const sel = window.getSelection()
+  if (sel?.rangeCount && editorRef.value?.contains(sel.anchorNode)) {
+    savedSelection = sel.getRangeAt(0).cloneRange()
+  }
+}
+
+function setFontSize(size: string) {
+  expandSelectionToVariables()
+  document.execCommand('fontSize', false, '7')
+  const fontEls = editorRef.value?.querySelectorAll('font[size="7"]')
+  const newSpans: HTMLElement[] = []
+  fontEls?.forEach(el => {
+    const span = document.createElement('span')
+    span.style.fontSize = size + 'px'
+    span.innerHTML = el.innerHTML
+    el.replaceWith(span)
+    newSpans.push(span)
+  })
+  if (newSpans.length) {
+    const sel = window.getSelection()
+    if (sel) {
+      const range = document.createRange()
+      const tw1 = document.createTreeWalker(newSpans[0], NodeFilter.SHOW_TEXT)
+      const firstText = tw1.nextNode()
+      const lastSpan = newSpans[newSpans.length - 1]
+      const tw2 = document.createTreeWalker(lastSpan, NodeFilter.SHOW_TEXT)
+      let lastText: Node | null = null
+      while (tw2.nextNode()) lastText = tw2.currentNode
+      if (firstText && lastText) {
+        range.setStart(firstText, 0)
+        range.setEnd(lastText, (lastText as Text).length)
+        sel.removeAllRanges()
+        sel.addRange(range)
+      }
+    }
+  }
+  editorRef.value?.focus()
+  onEditorInput()
+}
+
+function adjustFontSize(delta: number) {
+  const sel = window.getSelection()
+  if (!sel || !sel.rangeCount || !editorRef.value) return
+  const current = parseInt(curSize.value) || 12
+  const newSize = Math.max(8, Math.min(72, current + delta))
+  setFontSize(String(newSize))
+  curSize.value = String(newSize)
+}
+
+function addRecipient() {
+  recipients.value.push('')
+}
+
+function removeRecipient(index: number) {
+  recipients.value.splice(index, 1)
 }
 
 async function handleSave() {
   saving.value = true
   saved.value  = false
-  const result = await saveTemplate(activeDept.value, subject.value, body.value)
+  const validRecipients = recipients.value.map(r => r.trim()).filter(Boolean)
+  const result = await saveTemplate(activeDept.value, subject.value, body.value, validRecipients)
   saving.value = false
   if (result) {
     saved.value = true
@@ -100,6 +263,27 @@ async function handleSave() {
     <p v-if="loading" class="loading">Laden...</p>
 
     <form v-else class="detail-form" @submit.prevent="handleSave">
+      <!-- Recipients -->
+      <div class="form-group">
+        <label>Empfänger</label>
+        <div class="mail-recipients">
+          <div v-for="(_, i) in recipients" :key="i" class="mail-recipient-row">
+            <input
+              v-model="recipients[i]"
+              type="email"
+              placeholder="email@example.com"
+            />
+            <button
+              v-if="recipients.length > 1"
+              type="button"
+              class="btn-remove-sm"
+              @click="removeRecipient(i)"
+            >×</button>
+          </div>
+          <button type="button" class="btn-add" @click="addRecipient">+ Empfänger</button>
+        </div>
+      </div>
+
       <div class="form-group">
         <label>Betreff-Vorlage</label>
         <input v-model="subject" type="text" placeholder="Betreff…" />
@@ -107,7 +291,48 @@ async function handleSave() {
 
       <div class="form-group">
         <label>Nachricht-Vorlage</label>
-        <textarea v-model="body" rows="14" placeholder="Mail-Text…"></textarea>
+        <div class="rich-editor-toolbar">
+          <select class="toolbar-select" :value="curFont" @change="execCmd('fontName', ($event.target as HTMLSelectElement).value)" title="Schriftart">
+            <option value="" disabled>Schriftart</option>
+            <option value="Arial" style="font-family:Arial">Arial</option>
+            <option value="Helvetica" style="font-family:Helvetica">Helvetica</option>
+            <option value="Georgia" style="font-family:Georgia">Georgia</option>
+            <option value="Times New Roman" style="font-family:'Times New Roman'">Times New Roman</option>
+            <option value="Courier New" style="font-family:'Courier New'">Courier New</option>
+            <option value="Verdana" style="font-family:Verdana">Verdana</option>
+            <option value="Trebuchet MS" style="font-family:'Trebuchet MS'">Trebuchet MS</option>
+          </select>
+          <input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+          <button type="button" class="toolbar-btn-sm" @click="adjustFontSize(-2)" title="Kleiner">A−</button>
+          <button type="button" class="toolbar-btn-sm" @click="adjustFontSize(2)" title="Grösser">A+</button>
+          <span class="toolbar-sep"></span>
+          <button type="button" :class="{'toolbar-btn--active': curBold}" @click="execCmd('bold')" title="Fett"><b>B</b></button>
+          <button type="button" :class="{'toolbar-btn--active': curItalic}" @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
+          <button type="button" :class="{'toolbar-btn--active': curUnderline}" @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
+          <span class="toolbar-sep"></span>
+          <label class="toolbar-color" title="Schriftfarbe" @mousedown="saveSelection">
+            A
+            <input type="color" :value="curColor" @input="execCmd('foreColor', ($event.target as HTMLInputElement).value)" />
+          </label>
+          <label class="toolbar-color toolbar-color--bg" title="Hintergrundfarbe" @mousedown="saveSelection">
+            <span class="toolbar-color-icon">A</span>
+            <input type="color" :value="curBgColor" @input="execCmd('hiliteColor', ($event.target as HTMLInputElement).value)" />
+          </label>
+          <span class="toolbar-sep"></span>
+          <button type="button" :class="{'toolbar-btn--active': curUl}" @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
+          <button type="button" :class="{'toolbar-btn--active': curOl}" @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+          <span class="toolbar-sep"></span>
+          <button type="button" @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
+        </div>
+        <div
+          ref="editorRef"
+          class="rich-editor"
+          contenteditable="true"
+          @input="onEditorInput"
+          @mouseup="updateToolbarState"
+          @keyup="updateToolbarState"
+          data-placeholder="Mail-Text…"
+        ></div>
       </div>
 
       <!-- Variable reference -->

--- a/frontend/src/pages/MailTemplatePage.vue
+++ b/frontend/src/pages/MailTemplatePage.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useMailTemplates } from '../composables/useMailTemplates'
+import { useContactSearch } from '../composables/useContactSearch'
 import { user } from '../composables/useAuth'
-import type { Department } from '../types'
+import { wsSend, wsRegister, useWebSocket } from '../composables/useWebSocket'
+import type { Department, EditSection } from '../types'
 
 const ALL_DEPARTMENTS: Department[] = ['Leiter', 'Pio', 'Pfadi', 'Wölfe', 'Biber']
 
@@ -45,8 +47,6 @@ const activeDept = ref<Department>(
 const subject = ref('')
 const body = ref('')
 const recipients = ref<string[]>([''])
-const saving = ref(false)
-const saved = ref(false)
 const showVars = ref(false)
 const editorRef = ref<HTMLElement | null>(null)
 const curFont = ref('Arial')
@@ -60,26 +60,212 @@ const curOl = ref(false)
 const curBgColor = ref('#ffffff')
 let savedSelection: Range | null = null
 
+// ---- Dirty tracking & save indicator ----------------------------------------
+const dirtyFields = new Set<string>()
+const savedFields = ref<Record<string, number>>({})
+let savedTimer: ReturnType<typeof setTimeout> | null = null
+let suppressDirtyTracking = true
+let applyingRemote = false
+
+function markDirty(...fields: string[]) {
+  if (suppressDirtyTracking || applyingRemote) return
+  for (const f of fields) dirtyFields.add(f)
+}
+
+function showSavedIndicator() {
+  if (savedTimer) clearTimeout(savedTimer)
+  const snap: Record<string, number> = {}
+  for (const f of dirtyFields) snap[f] = Date.now()
+  dirtyFields.clear()
+  savedFields.value = snap
+  savedTimer = setTimeout(() => { savedFields.value = {} }, 2000)
+}
+
+// ---- Collaborative editing state -------------------------------------------
+const activeEditors = ref<string[]>([])
+const sectionLocks = ref<Map<EditSection, string>>(new Map())
+const myLockedSection = ref<EditSection | null>(null)
+
+function tplId() { return `tpl_${activeDept.value}` }
+
+function isLockedByOther(section: EditSection): boolean {
+  const locker = sectionLocks.value.get(section)
+  return !!locker && locker !== user.value?.display_name
+}
+function lockedBy(section: EditSection): string | null {
+  const locker = sectionLocks.value.get(section)
+  return locker && locker !== user.value?.display_name ? locker : null
+}
+
+function lockSection(section: EditSection) {
+  if (isLockedByOther(section)) return
+  if (myLockedSection.value === section) return
+  if (myLockedSection.value) {
+    wsSend({ type: 'unlock', activity_id: tplId(), section: myLockedSection.value })
+  }
+  myLockedSection.value = section
+  wsSend({ type: 'lock', activity_id: tplId(), section })
+}
+
+let unlockTimer: ReturnType<typeof setTimeout> | null = null
+function unlockSection(section: EditSection, event?: FocusEvent) {
+  if (myLockedSection.value !== section) return
+  if (event?.relatedTarget instanceof HTMLElement) {
+    const wrapper = (event.currentTarget as HTMLElement)
+    if (wrapper?.contains(event.relatedTarget)) return
+  }
+  if (unlockTimer) clearTimeout(unlockTimer)
+  unlockTimer = setTimeout(() => {
+    if (myLockedSection.value === section) {
+      myLockedSection.value = null
+      wsSend({ type: 'unlock', activity_id: tplId(), section })
+    }
+  }, 100)
+}
+
+// ---- Auto-save --------------------------------------------------------------
+const AUTOSAVE_INTERVAL = Number(import.meta.env.VITE_AUTOSAVE_INTERVAL) || 1500
+const AUTOSAVE_DEBOUNCE = (import.meta.env.VITE_AUTOSAVE_DEBOUNCE ?? 'true') !== 'false'
+
+let autoSaveTimer: ReturnType<typeof setTimeout> | null = null
+let autoSaveInterval: ReturnType<typeof setInterval> | null = null
+let hasPendingChanges = false
+
+function scheduleAutoSave() {
+  if (applyingRemote) return
+  if (AUTOSAVE_DEBOUNCE) {
+    if (autoSaveTimer) clearTimeout(autoSaveTimer)
+    autoSaveTimer = setTimeout(doSave, AUTOSAVE_INTERVAL)
+  } else {
+    hasPendingChanges = true
+  }
+}
+
+function startAutoSaveInterval() {
+  if (!AUTOSAVE_DEBOUNCE && !autoSaveInterval) {
+    autoSaveInterval = setInterval(() => {
+      if (hasPendingChanges) {
+        hasPendingChanges = false
+        doSave()
+      }
+    }, AUTOSAVE_INTERVAL)
+  }
+}
+
+function stopAutoSaveInterval() {
+  if (autoSaveInterval) {
+    clearInterval(autoSaveInterval)
+    autoSaveInterval = null
+  }
+  hasPendingChanges = false
+}
+
+async function doSave() {
+  error.value = null
+  const validRecipients = recipients.value.map(r => r.trim()).filter(Boolean)
+  const result = await saveTemplate(activeDept.value, subject.value, body.value, validRecipients)
+  if (result) {
+    showSavedIndicator()
+    const idx = templates.value.findIndex(t => t.department === activeDept.value)
+    if (idx >= 0) templates.value[idx] = result
+    else templates.value.push(result)
+  }
+}
+
+// Watchers for auto-save + dirty tracking
+watch([subject], () => { markDirty('subject'); scheduleAutoSave() })
+watch([recipients], () => { markDirty('recipients'); scheduleAutoSave() }, { deep: true })
+// body changes are triggered by onEditorInput which calls scheduleAutoSave directly
+
+// ---- WS: live sync of template updates from other editors ------------------
+useWebSocket((e) => {
+  const id = tplId()
+  if (e.event === 'lock' && e.activity_id === id) {
+    sectionLocks.value.set(e.section, e.user)
+    sectionLocks.value = new Map(sectionLocks.value)
+  } else if (e.event === 'unlock' && e.activity_id === id) {
+    sectionLocks.value.delete(e.section)
+    sectionLocks.value = new Map(sectionLocks.value)
+  } else if (e.event === 'editors' && e.activity_id === id) {
+    activeEditors.value = e.users.filter((u: string) => u !== user.value?.display_name)
+  } else if (e.event === 'locks_state' && e.activity_id === id) {
+    const m = new Map<EditSection, string>()
+    for (const l of e.locks) {
+      m.set(l.section, l.user)
+    }
+    sectionLocks.value = m
+  } else if (e.event === 'template_updated') {
+    const tpl = e.template
+    if (tpl.department !== activeDept.value) return
+    // Update local templates cache
+    const idx = templates.value.findIndex(t => t.department === tpl.department)
+    if (idx >= 0) templates.value[idx] = tpl
+    else templates.value.push(tpl)
+    // Merge remote changes into edit fields
+    applyingRemote = true
+    if (tpl.subject !== subject.value && !myLockedSection.value?.startsWith('tpl_subject')) {
+      subject.value = tpl.subject
+    }
+    if (JSON.stringify(tpl.recipients) !== JSON.stringify(recipients.value.map(r => r.trim()).filter(Boolean))
+        && !myLockedSection.value?.startsWith('tpl_recipients')) {
+      recipients.value = tpl.recipients.length ? [...tpl.recipients] : ['']
+    }
+    if (tpl.body !== body.value && !myLockedSection.value?.startsWith('tpl_body')) {
+      body.value = tpl.body
+      nextTick(() => {
+        if (editorRef.value) editorRef.value.innerHTML = body.value
+      })
+    }
+    nextTick(() => { applyingRemote = false })
+  }
+})
+
+// ---- Load + mount -----------------------------------------------------------
 onMounted(async () => {
   await fetchTemplates()
   loadDept(activeDept.value)
+  if (user.value) {
+    wsRegister(user.value.display_name, user.value.microsoft_oid)
+    wsSend({ type: 'join', activity_id: tplId() })
+  }
+  startAutoSaveInterval()
+})
+
+onUnmounted(() => {
+  if (autoSaveTimer) clearTimeout(autoSaveTimer)
+  if (savedTimer) clearTimeout(savedTimer)
+  stopAutoSaveInterval()
+  wsSend({ type: 'leave', activity_id: tplId() })
 })
 
 function loadDept(dept: Department) {
+  // Leave previous template room
+  wsSend({ type: 'leave', activity_id: tplId() })
+  myLockedSection.value = null
+  sectionLocks.value = new Map()
+  activeEditors.value = []
+
+  suppressDirtyTracking = true
   activeDept.value = dept
-  saved.value = false
   const tpl = templates.value.find(t => t.department === dept)
   subject.value = tpl?.subject ?? ''
   body.value    = tpl?.body ?? ''
   recipients.value = tpl?.recipients?.length ? [...tpl.recipients] : ['']
   nextTick(() => {
     if (editorRef.value) editorRef.value.innerHTML = body.value
+    suppressDirtyTracking = false
+    dirtyFields.clear()
   })
+
+  // Join new template room
+  wsSend({ type: 'join', activity_id: tplId() })
 }
 
 function onEditorInput() {
   if (editorRef.value) body.value = editorRef.value.innerHTML
   updateToolbarState()
+  markDirty('body')
+  scheduleAutoSave()
 }
 
 function updateToolbarState() {
@@ -112,7 +298,6 @@ function expandSelectionToVariables() {
   const range = sel.getRangeAt(0)
   const container = editorRef.value
   const fullText = container.textContent ?? ''
-  // Map range start/end to text offsets, then expand if inside a {{...}}
   function nodeOffset(node: Node, off: number): number {
     const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
     let pos = 0
@@ -134,7 +319,6 @@ function expandSelectionToVariables() {
   }
   let startOff = nodeOffset(range.startContainer, range.startOffset)
   let endOff = nodeOffset(range.endContainer, range.endOffset)
-  // Expand start backwards if inside a variable
   const varPattern = /\{\{\w+\}\}/g
   let m: RegExpExecArray | null
   while ((m = varPattern.exec(fullText)) !== null) {
@@ -214,25 +398,47 @@ function adjustFontSize(delta: number) {
   curSize.value = String(newSize)
 }
 
-function addRecipient() {
-  recipients.value.push('')
+// ---- Recipient contact search -----------------------------------------------
+const { results: contactResults, searching: contactSearching, search: searchContacts, clear: clearContactSearch } = useContactSearch()
+const recipientSearch = ref('')
+const showRecipientDropdown = ref(false)
+
+function onRecipientSearchInput() {
+  searchContacts(recipientSearch.value)
+}
+
+function addRecipient(email: string) {
+  if (!recipients.value.includes(email)) {
+    // Replace the empty sentinel if present
+    if (recipients.value.length === 1 && recipients.value[0] === '') {
+      recipients.value[0] = email
+    } else {
+      recipients.value.push(email)
+    }
+  }
+  recipientSearch.value = ''
+  showRecipientDropdown.value = false
+  clearContactSearch()
 }
 
 function removeRecipient(index: number) {
   recipients.value.splice(index, 1)
+  if (recipients.value.length === 0) recipients.value = ['']
 }
 
-async function handleSave() {
-  saving.value = true
-  saved.value  = false
-  const validRecipients = recipients.value.map(r => r.trim()).filter(Boolean)
-  const result = await saveTemplate(activeDept.value, subject.value, body.value, validRecipients)
-  saving.value = false
-  if (result) {
-    saved.value = true
-    const idx = templates.value.findIndex(t => t.department === activeDept.value)
-    if (idx >= 0) templates.value[idx] = result
-    else templates.value.push(result)
+function onRecipientBlur() {
+  setTimeout(() => {
+    showRecipientDropdown.value = false
+  }, 200)
+}
+
+function onRecipientKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    const val = recipientSearch.value.trim()
+    if (val && val.includes('@')) {
+      addRecipient(val)
+    }
   }
 }
 </script>
@@ -262,35 +468,69 @@ async function handleSave() {
 
     <p v-if="loading" class="loading">Laden...</p>
 
-    <form v-else class="detail-form" @submit.prevent="handleSave">
+    <div v-else class="detail-form">
+      <!-- Active editors indicator -->
+      <div v-if="activeEditors.length" class="editors-banner">
+        <span class="editors-banner-icon">👥</span>
+        <span>{{ activeEditors.join(', ') }} {{ activeEditors.length === 1 ? 'bearbeitet' : 'bearbeiten' }} ebenfalls</span>
+      </div>
+
       <!-- Recipients -->
-      <div class="form-group">
-        <label>Empfänger</label>
-        <div class="mail-recipients">
-          <div v-for="(_, i) in recipients" :key="i" class="mail-recipient-row">
-            <input
-              v-model="recipients[i]"
-              type="email"
-              placeholder="email@example.com"
-            />
-            <button
-              v-if="recipients.length > 1"
-              type="button"
-              class="btn-remove-sm"
-              @click="removeRecipient(i)"
-            >×</button>
+      <div class="form-group lock-wrapper user-search-group" :class="{ 'is-locked': isLockedByOther('tpl_recipients') }"
+        @focusin="lockSection('tpl_recipients')" @focusout="unlockSection('tpl_recipients', $event)">
+        <div v-if="lockedBy('tpl_recipients')" class="lock-badge">🔒 {{ lockedBy('tpl_recipients') }}</div>
+        <label>Empfänger
+          <span v-if="savedFields['recipients']" class="field-saved-icon field-saved-icon--inline" :key="savedFields['recipients']">💾</span>
+        </label>
+        <div class="user-chips" v-if="recipients.filter(r => r).length">
+          <span v-for="(email, i) in recipients" :key="email || i" class="user-chip" v-show="email">
+            {{ email }}
+            <button type="button" class="user-chip-remove" @click="removeRecipient(i)" :disabled="isLockedByOther('tpl_recipients')">✕</button>
+          </span>
+        </div>
+        <div class="user-search-wrapper">
+          <input
+            type="text"
+            v-model="recipientSearch"
+            placeholder="Kontakt suchen…"
+            @input="onRecipientSearchInput"
+            @focus="showRecipientDropdown = true"
+            @blur="onRecipientBlur"
+            @keydown="onRecipientKeydown"
+            :disabled="isLockedByOther('tpl_recipients')"
+          />
+          <div v-if="showRecipientDropdown && (contactResults.length || contactSearching)" class="user-dropdown">
+            <div v-if="contactSearching" class="user-dropdown-item user-dropdown-item--loading">Suchen…</div>
+            <div
+              v-for="c in contactResults"
+              :key="c.email"
+              class="user-dropdown-item"
+              @mousedown.prevent="addRecipient(c.email)"
+            >
+              <span class="contact-name">{{ c.displayName }}</span>
+              <span class="contact-email">{{ c.email }}</span>
+            </div>
           </div>
-          <button type="button" class="btn-add" @click="addRecipient">+ Empfänger</button>
         </div>
       </div>
 
-      <div class="form-group">
+      <div class="form-group lock-wrapper" :class="{ 'is-locked': isLockedByOther('tpl_subject') }"
+        @focusin="lockSection('tpl_subject')" @focusout="unlockSection('tpl_subject', $event)">
+        <div v-if="lockedBy('tpl_subject')" class="lock-badge">🔒 {{ lockedBy('tpl_subject') }}</div>
         <label>Betreff-Vorlage</label>
-        <input v-model="subject" type="text" placeholder="Betreff…" />
+        <div class="input-save-wrap">
+          <input v-model="subject" type="text" placeholder="Betreff…" :disabled="isLockedByOther('tpl_subject')" />
+          <span v-if="savedFields['subject']" class="field-saved-icon" :key="savedFields['subject']">💾</span>
+        </div>
       </div>
 
-      <div class="form-group">
+      <div class="form-group lock-wrapper" :class="{ 'is-locked': isLockedByOther('tpl_body') }"
+        @focusin="lockSection('tpl_body')" @focusout="unlockSection('tpl_body', $event)">
+        <div v-if="lockedBy('tpl_body')" class="lock-badge">🔒 {{ lockedBy('tpl_body') }}</div>
         <label>Nachricht-Vorlage</label>
+        <div class="input-save-wrap">
+          <span v-if="savedFields['body']" class="field-saved-icon field-saved-icon--textarea" :key="savedFields['body']">💾</span>
+        </div>
         <div class="rich-editor-toolbar">
           <select class="toolbar-select" :value="curFont" @change="execCmd('fontName', ($event.target as HTMLSelectElement).value)" title="Schriftart">
             <option value="" disabled>Schriftart</option>
@@ -327,7 +567,7 @@ async function handleSave() {
         <div
           ref="editorRef"
           class="rich-editor"
-          contenteditable="true"
+          :contenteditable="!isLockedByOther('tpl_body')"
           @input="onEditorInput"
           @mouseup="updateToolbarState"
           @keyup="updateToolbarState"
@@ -349,15 +589,6 @@ async function handleSave() {
       </div>
 
       <p v-if="error" class="error">{{ error }}</p>
-
-      <div class="form-actions">
-        <span v-if="saved" class="mail-saved-badge">✅ Gespeichert</span>
-        <div class="form-actions-right">
-          <button type="submit" class="btn-primary" :disabled="saving">
-            {{ saving ? 'Speichern...' : 'Vorlage speichern' }}
-          </button>
-        </div>
-      </div>
-    </form>
+    </div>
   </main>
 </template>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -96,6 +96,7 @@ export interface MailTemplate {
 	department: Department;
 	subject: string;
 	body: string;
+	recipients: string[];
 	created_at: string;
 	updated_at: string;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -64,7 +64,10 @@ export type EditSection =
 	| `program_${number}`
 	| `material_${number}`
 	| 'siko'
-	| 'goal_weather';
+	| 'goal_weather'
+	| 'tpl_recipients'
+	| 'tpl_subject'
+	| 'tpl_body';
 
 export interface SectionLock {
 	section: EditSection;
@@ -75,6 +78,7 @@ export type WsEvent =
 	| { event: 'created'; activity: Activity }
 	| { event: 'updated'; activity: Activity }
 	| { event: 'deleted'; id: string }
+	| { event: 'template_updated'; template: MailTemplate }
 	| { event: 'lock'; activity_id: string; section: EditSection; user: string }
 	| { event: 'unlock'; activity_id: string; section: EditSection }
 	| { event: 'editors'; activity_id: string; users: string[] }
@@ -99,4 +103,15 @@ export interface MailTemplate {
 	recipients: string[];
 	created_at: string;
 	updated_at: string;
+}
+
+export interface SentMail {
+	id: string;
+	activity_id: string;
+	sender_id: string;
+	sender_email: string;
+	to_emails: string[];
+	subject: string;
+	body_html: string;
+	sent_at: string;
 }


### PR DESCRIPTION
…blen

Änderungen:
- Mail-Vorlagen Link aus UserAvatar-Dropdown entfernt
- Empfänger-Feld auf Mail-Vorlagen-Seite hinzugefügt (werden automatisch in neue Mails übernommen)
- Textfeld durch Rich-Text-Editor ersetzt (contenteditable + Toolbar)
- Toolbar: Schriftart, Grösse (freies Textfeld + A±-Buttons), Fett, Kursiv, Unterstrichen, Schrift-/Hintergrundfarbe, Listen, Format entfernen
- Neue Template-Variablen: {{absender_email}}, {{absender_name}}, {{datum_kurz}}
- Variablen-Ersetzung via DOM-TreeWalker (erhält Formatierung)
- Variablen werden atomar formatiert (Selektion wird automatisch auf ganze {{variable}} erweitert)
- Selektion bleibt bei Grössenänderung und Farbwahl erhalten
- Toolbar zeigt aktiven Zustand aller Formatierungen (Bold/Italic/Underline/Listen/Farben/Grösse)
- Backend: recipients-Feld in mail_templates (TEXT[])
- Seed-Daten mit HTML-Body und Empfängern aktualisiert

Zu testen:
- [x] Mail-Vorlagen bearbeiten: Empfänger hinzufügen/entfernen, Speichern & Neuladen
- [x] Rich-Editor: Text markieren → Schriftart/Grösse/Farbe/Fett/Kursiv/Unterstrichen ändern
- [ ] Grössen-Buttons (A−/A+): Mehrfach hintereinander klicken, Text muss markiert bleiben
- [x] Hintergrundfarbe: Text markieren → Farbe wählen → Selektion darf nicht verloren gehen
- [x] Variablen (z.B. {{titel}}): Teilweise markieren → Formatierung muss ganze Variable umfassen
- [x] Mail senden: Vorlage mit Variablen + Formatierung laden → Variablen korrekt ersetzt, Formatierung erhalten
- [x] Empfänger aus Vorlage werden beim Öffnen des Mail-Formulars vorausgefüllt
- [x] Toolbar-Status: Cursor in formatierten Text setzen → Toolbar zeigt aktuelle Werte (Schrift, Grösse, Farbe, B/I/U)