### PR TITLE
fix: Rich-Text-Editor Toolbar-Probleme beheben

### DIFF
--- a/frontend/src/pages/DetailPage.vue
+++ b/frontend/src/pages/DetailPage.vue
@@ -427,6 +427,31 @@ function progExecCmd(i: number, cmd: string, value?: string) {
 }
 
 function progSetFontSize(i: number, size: string) {
+	if (progSavedSelection) {
+		const sel = window.getSelection();
+		if (sel) { sel.removeAllRanges(); sel.addRange(progSavedSelection); }
+		progSavedSelection = null;
+	}
+	const sel = window.getSelection();
+	if (sel && sel.rangeCount && sel.getRangeAt(0).collapsed) {
+		// Collapsed cursor: insert a zero-width space inside a styled span
+		const span = document.createElement('span');
+		span.style.fontSize = size + 'px';
+		span.textContent = '\u200B';
+		const range = sel.getRangeAt(0);
+		range.insertNode(span);
+		// Place cursor after the ZWS inside the span
+		const newRange = document.createRange();
+		newRange.setStart(span.firstChild!, 1);
+		newRange.collapse(true);
+		sel.removeAllRanges();
+		sel.addRange(newRange);
+		const el = progEditorRefs.value[i];
+		el?.focus();
+		if (progToolbar.value) progToolbar.value.size = size;
+		onProgDescInput(i);
+		return;
+	}
 	document.execCommand('fontSize', false, '7');
 	const el = progEditorRefs.value[i];
 	const fontEls = el?.querySelectorAll('font[size="7"]');
@@ -927,13 +952,13 @@ async function doDelete() {
 											<option value="Courier New" style="font-family:'Courier New'">Courier New</option>
 											<option value="Verdana" style="font-family:Verdana">Verdana</option>
 										</select>
-										<input type="text" class="toolbar-select toolbar-select--narrow" :value="progToolbar.size" @change="progSetFontSize(i, ($event.target as HTMLInputElement).value)" @keydown.enter.prevent="progSetFontSize(i, ($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
-										<button type="button" class="toolbar-btn-sm" @click="progAdjustFontSize(i, -2)" title="Kleiner">A−</button>
-										<button type="button" class="toolbar-btn-sm" @click="progAdjustFontSize(i, 2)" title="Grösser">A+</button>
+										<input type="text" class="toolbar-select toolbar-select--narrow" :value="progToolbar.size" @mousedown="progSaveSelection" @change="progSetFontSize(i, ($event.target as HTMLInputElement).value)" @keydown.enter.prevent="progSetFontSize(i, ($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+										<button type="button" class="toolbar-btn-sm" @mousedown.prevent @click="progAdjustFontSize(i, -2)" title="Kleiner">A−</button>
+										<button type="button" class="toolbar-btn-sm" @mousedown.prevent @click="progAdjustFontSize(i, 2)" title="Grösser">A+</button>
 										<span class="toolbar-sep"></span>
-										<button type="button" :class="{'toolbar-btn--active': progToolbar.bold}" @click="progExecCmd(i, 'bold')" title="Fett"><b>B</b></button>
-										<button type="button" :class="{'toolbar-btn--active': progToolbar.italic}" @click="progExecCmd(i, 'italic')" title="Kursiv"><i>I</i></button>
-										<button type="button" :class="{'toolbar-btn--active': progToolbar.underline}" @click="progExecCmd(i, 'underline')" title="Unterstrichen"><u>U</u></button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.bold}" @mousedown.prevent @click="progExecCmd(i, 'bold')" title="Fett"><b>B</b></button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.italic}" @mousedown.prevent @click="progExecCmd(i, 'italic')" title="Kursiv"><i>I</i></button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.underline}" @mousedown.prevent @click="progExecCmd(i, 'underline')" title="Unterstrichen"><u>U</u></button>
 										<span class="toolbar-sep"></span>
 										<label class="toolbar-color" title="Schriftfarbe" @mousedown="progSaveSelection">
 											A
@@ -944,10 +969,10 @@ async function doDelete() {
 											<input type="color" :value="progToolbar.bgColor" @input="progExecCmd(i, 'hiliteColor', ($event.target as HTMLInputElement).value)" />
 										</label>
 										<span class="toolbar-sep"></span>
-										<button type="button" :class="{'toolbar-btn--active': progToolbar.ul}" @click="progExecCmd(i, 'insertUnorderedList')" title="Aufzählung">• Liste</button>
-										<button type="button" :class="{'toolbar-btn--active': progToolbar.ol}" @click="progExecCmd(i, 'insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.ul}" @mousedown.prevent @click="progExecCmd(i, 'insertUnorderedList')" title="Aufzählung">• Liste</button>
+										<button type="button" :class="{'toolbar-btn--active': progToolbar.ol}" @mousedown.prevent @click="progExecCmd(i, 'insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
 										<span class="toolbar-sep"></span>
-										<button type="button" @click="progExecCmd(i, 'removeFormat')" title="Formatierung entfernen">✕ Format</button>
+										<button type="button" @mousedown.prevent @click="progExecCmd(i, 'removeFormat')" title="Formatierung entfernen">✕ Format</button>
 									</div>
 									<div
 										:ref="(el) => setProgEditorRef(el, i)"

--- a/frontend/src/pages/MailComposerPage.vue
+++ b/frontend/src/pages/MailComposerPage.vue
@@ -156,6 +156,7 @@ function expandSelectionToVariables() {
   const sel = window.getSelection()
   if (!sel || !sel.rangeCount || !editorRef.value) return
   const range = sel.getRangeAt(0)
+  if (range.collapsed) return
   const container = editorRef.value
   const fullText = container.textContent ?? ''
   function nodeOffset(node: Node, off: number): number {
@@ -216,6 +217,30 @@ function saveSelection() {
 }
 
 function setFontSize(size: string) {
+  if (savedSelection) {
+    const sel = window.getSelection()
+    if (sel) { sel.removeAllRanges(); sel.addRange(savedSelection) }
+    savedSelection = null
+  }
+  const sel = window.getSelection()
+  if (sel && sel.rangeCount && sel.getRangeAt(0).collapsed) {
+    // Collapsed cursor: insert a zero-width space inside a styled span
+    const span = document.createElement('span')
+    span.style.fontSize = size + 'px'
+    span.textContent = '\u200B'
+    const range = sel.getRangeAt(0)
+    range.insertNode(span)
+    // Place cursor after the ZWS inside the span
+    const newRange = document.createRange()
+    newRange.setStart(span.firstChild!, 1)
+    newRange.collapse(true)
+    sel.removeAllRanges()
+    sel.addRange(newRange)
+    editorRef.value?.focus()
+    curSize.value = size
+    onEditorInput()
+    return
+  }
   expandSelectionToVariables()
   document.execCommand('fontSize', false, '7')
   const fontEls = editorRef.value?.querySelectorAll('font[size="7"]')
@@ -228,8 +253,8 @@ function setFontSize(size: string) {
     newSpans.push(span)
   })
   if (newSpans.length) {
-    const sel = window.getSelection()
-    if (sel) {
+    const sel2 = window.getSelection()
+    if (sel2) {
       const range = document.createRange()
       const tw1 = document.createTreeWalker(newSpans[0], NodeFilter.SHOW_TEXT)
       const firstText = tw1.nextNode()
@@ -240,8 +265,8 @@ function setFontSize(size: string) {
       if (firstText && lastText) {
         range.setStart(firstText, 0)
         range.setEnd(lastText, (lastText as Text).length)
-        sel.removeAllRanges()
-        sel.addRange(range)
+        sel2.removeAllRanges()
+        sel2.addRange(range)
       }
     }
   }
@@ -484,13 +509,13 @@ function closeMailViewer() {
 						<option value="Verdana" style="font-family:Verdana">Verdana</option>
 						<option value="Trebuchet MS" style="font-family:'Trebuchet MS'">Trebuchet MS</option>
 					</select>
-					<input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
-					<button type="button" class="toolbar-btn-sm" @click="adjustFontSize(-2)" title="Kleiner">A−</button>
-					<button type="button" class="toolbar-btn-sm" @click="adjustFontSize(2)" title="Grösser">A+</button>
+					<input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @mousedown="saveSelection" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+					<button type="button" class="toolbar-btn-sm" @mousedown.prevent @click="adjustFontSize(-2)" title="Kleiner">A−</button>
+					<button type="button" class="toolbar-btn-sm" @mousedown.prevent @click="adjustFontSize(2)" title="Grösser">A+</button>
 					<span class="toolbar-sep"></span>
-					<button type="button" :class="{'toolbar-btn--active': curBold}" @click="execCmd('bold')" title="Fett"><b>B</b></button>
-					<button type="button" :class="{'toolbar-btn--active': curItalic}" @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
-					<button type="button" :class="{'toolbar-btn--active': curUnderline}" @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
+					<button type="button" :class="{'toolbar-btn--active': curBold}" @mousedown.prevent @click="execCmd('bold')" title="Fett"><b>B</b></button>
+					<button type="button" :class="{'toolbar-btn--active': curItalic}" @mousedown.prevent @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
+					<button type="button" :class="{'toolbar-btn--active': curUnderline}" @mousedown.prevent @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
 					<span class="toolbar-sep"></span>
 					<label class="toolbar-color" title="Schriftfarbe" @mousedown="saveSelection">
 						A
@@ -501,10 +526,10 @@ function closeMailViewer() {
 						<input type="color" :value="curBgColor" @input="execCmd('hiliteColor', ($event.target as HTMLInputElement).value)" />
 					</label>
 					<span class="toolbar-sep"></span>
-					<button type="button" :class="{'toolbar-btn--active': curUl}" @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
-					<button type="button" :class="{'toolbar-btn--active': curOl}" @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+					<button type="button" :class="{'toolbar-btn--active': curUl}" @mousedown.prevent @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
+					<button type="button" :class="{'toolbar-btn--active': curOl}" @mousedown.prevent @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
 					<span class="toolbar-sep"></span>
-					<button type="button" @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
+					<button type="button" @mousedown.prevent @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
 				</div>
 				<div
 					ref="editorRef"

--- a/frontend/src/pages/MailTemplatePage.vue
+++ b/frontend/src/pages/MailTemplatePage.vue
@@ -296,6 +296,7 @@ function expandSelectionToVariables() {
   const sel = window.getSelection()
   if (!sel || !sel.rangeCount || !editorRef.value) return
   const range = sel.getRangeAt(0)
+  if (range.collapsed) return
   const container = editorRef.value
   const fullText = container.textContent ?? ''
   function nodeOffset(node: Node, off: number): number {
@@ -356,6 +357,30 @@ function saveSelection() {
 }
 
 function setFontSize(size: string) {
+  if (savedSelection) {
+    const sel = window.getSelection()
+    if (sel) { sel.removeAllRanges(); sel.addRange(savedSelection) }
+    savedSelection = null
+  }
+  const sel = window.getSelection()
+  if (sel && sel.rangeCount && sel.getRangeAt(0).collapsed) {
+    // Collapsed cursor: insert a zero-width space inside a styled span
+    const span = document.createElement('span')
+    span.style.fontSize = size + 'px'
+    span.textContent = '\u200B'
+    const range = sel.getRangeAt(0)
+    range.insertNode(span)
+    // Place cursor after the ZWS inside the span
+    const newRange = document.createRange()
+    newRange.setStart(span.firstChild!, 1)
+    newRange.collapse(true)
+    sel.removeAllRanges()
+    sel.addRange(newRange)
+    editorRef.value?.focus()
+    curSize.value = size
+    onEditorInput()
+    return
+  }
   expandSelectionToVariables()
   document.execCommand('fontSize', false, '7')
   const fontEls = editorRef.value?.querySelectorAll('font[size="7"]')
@@ -368,8 +393,8 @@ function setFontSize(size: string) {
     newSpans.push(span)
   })
   if (newSpans.length) {
-    const sel = window.getSelection()
-    if (sel) {
+    const sel2 = window.getSelection()
+    if (sel2) {
       const range = document.createRange()
       const tw1 = document.createTreeWalker(newSpans[0], NodeFilter.SHOW_TEXT)
       const firstText = tw1.nextNode()
@@ -380,8 +405,8 @@ function setFontSize(size: string) {
       if (firstText && lastText) {
         range.setStart(firstText, 0)
         range.setEnd(lastText, (lastText as Text).length)
-        sel.removeAllRanges()
-        sel.addRange(range)
+        sel2.removeAllRanges()
+        sel2.addRange(range)
       }
     }
   }
@@ -542,13 +567,13 @@ function onRecipientKeydown(e: KeyboardEvent) {
             <option value="Verdana" style="font-family:Verdana">Verdana</option>
             <option value="Trebuchet MS" style="font-family:'Trebuchet MS'">Trebuchet MS</option>
           </select>
-          <input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
-          <button type="button" class="toolbar-btn-sm" @click="adjustFontSize(-2)" title="Kleiner">A−</button>
-          <button type="button" class="toolbar-btn-sm" @click="adjustFontSize(2)" title="Grösser">A+</button>
+          <input type="text" class="toolbar-select toolbar-select--narrow" :value="curSize" @mousedown="saveSelection" @change="setFontSize(($event.target as HTMLInputElement).value)" @keydown.enter.prevent="setFontSize(($event.target as HTMLInputElement).value)" title="Schriftgrösse" />
+          <button type="button" class="toolbar-btn-sm" @mousedown.prevent @click="adjustFontSize(-2)" title="Kleiner">A−</button>
+          <button type="button" class="toolbar-btn-sm" @mousedown.prevent @click="adjustFontSize(2)" title="Grösser">A+</button>
           <span class="toolbar-sep"></span>
-          <button type="button" :class="{'toolbar-btn--active': curBold}" @click="execCmd('bold')" title="Fett"><b>B</b></button>
-          <button type="button" :class="{'toolbar-btn--active': curItalic}" @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
-          <button type="button" :class="{'toolbar-btn--active': curUnderline}" @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
+          <button type="button" :class="{'toolbar-btn--active': curBold}" @mousedown.prevent @click="execCmd('bold')" title="Fett"><b>B</b></button>
+          <button type="button" :class="{'toolbar-btn--active': curItalic}" @mousedown.prevent @click="execCmd('italic')" title="Kursiv"><i>I</i></button>
+          <button type="button" :class="{'toolbar-btn--active': curUnderline}" @mousedown.prevent @click="execCmd('underline')" title="Unterstrichen"><u>U</u></button>
           <span class="toolbar-sep"></span>
           <label class="toolbar-color" title="Schriftfarbe" @mousedown="saveSelection">
             A
@@ -559,10 +584,10 @@ function onRecipientKeydown(e: KeyboardEvent) {
             <input type="color" :value="curBgColor" @input="execCmd('hiliteColor', ($event.target as HTMLInputElement).value)" />
           </label>
           <span class="toolbar-sep"></span>
-          <button type="button" :class="{'toolbar-btn--active': curUl}" @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
-          <button type="button" :class="{'toolbar-btn--active': curOl}" @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
+          <button type="button" :class="{'toolbar-btn--active': curUl}" @mousedown.prevent @click="execCmd('insertUnorderedList')" title="Aufzählung">• Liste</button>
+          <button type="button" :class="{'toolbar-btn--active': curOl}" @mousedown.prevent @click="execCmd('insertOrderedList')" title="Nummerierte Liste">1. Liste</button>
           <span class="toolbar-sep"></span>
-          <button type="button" @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
+          <button type="button" @mousedown.prevent @click="execCmd('removeFormat')" title="Formatierung entfernen">✕ Format</button>
         </div>
         <div
           ref="editorRef"


### PR DESCRIPTION
- Schriftgrösse bei kollabiertem Cursor: Zero-Width-Space (ZWS) Span wird eingefügt, damit nachfolgende Eingaben die gewählte Grösse übernehmen (document.execCommand('fontSize') erfordert Selektion)
- @mousedown.prevent auf allen Toolbar-Buttons (B, I, U, Listen, Format, A−, A+) um Fokusverlust des Editors zu verhindern
- @mousedown='saveSelection' auf Schriftgrössen-Input um die Cursor-Position beim Klick zu bewahren
- expandSelectionToVariables(): Early-Return bei kollabiertem Cursor, da der TreeWalker sonst auf leeren Zeilen zum letzten Textknoten springt

Betrifft: MailTemplatePage, MailComposerPage, DetailPage