### PR TITLE
feat: Aktivitaets-Papierkorb mit Admin-Restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ UWEBSOCKETS_VERSION := v20.62.0
 USOCKETS_VERSION    := v0.8.8
 
 # Dev-Compose-Datei (docker-compose.yml = Produktion mit GHCR-Images)
-DC := podman compose -f docker-compose-dev.yml
+DC := docker compose -f docker-compose-dev.yml
 
 .PHONY: up down build rebuild logs logs-backend logs-frontend logs-db \
        restart restart-backend restart-frontend restart-db \

--- a/backend/src/db.cpp
+++ b/backend/src/db.cpp
@@ -917,6 +917,44 @@ bool Database::restore_activity(const std::string &id)
     return ok;
 }
 
+bool Database::permanently_delete_activity(const std::string &id)
+{
+    ensure_connected();
+    const char *params[1] = {id.c_str()};
+    PGresult *res = PQexecParams(conn_,
+                                 "DELETE FROM activities "
+                                 "WHERE id = $1 AND deleted_at IS NOT NULL",
+                                 1, nullptr, params, nullptr, nullptr, 0);
+    bool ok = PQresultStatus(res) == PGRES_COMMAND_OK && PQcmdTuples(res)[0] != '0';
+    PQclear(res);
+    return ok;
+}
+
+int Database::purge_deleted_activities_older_than_days(int days)
+{
+    ensure_connected();
+    std::string days_text = std::to_string(days);
+    const char *params[1] = {days_text.c_str()};
+    PGresult *res = PQexecParams(conn_,
+                                 "DELETE FROM activities "
+                                 "WHERE deleted_at IS NOT NULL "
+                                 "AND deleted_at < NOW() - ($1::int * INTERVAL '1 day')",
+                                 1, nullptr, params, nullptr, nullptr, 0);
+    if (PQresultStatus(res) != PGRES_COMMAND_OK)
+    {
+        std::string err = PQresultErrorMessage(res);
+        PQclear(res);
+        throw std::runtime_error("purge_deleted_activities_older_than_days: " + err);
+    }
+
+    int deleted = 0;
+    const char *tuples = PQcmdTuples(res);
+    if (tuples && *tuples)
+        deleted = std::atoi(tuples);
+    PQclear(res);
+    return deleted;
+}
+
 std::vector<DeletedActivityRecord> Database::list_deleted_activities()
 {
     ensure_connected();

--- a/backend/src/db.cpp
+++ b/backend/src/db.cpp
@@ -565,7 +565,7 @@ std::vector<Activity> Database::list_activities()
                            "SELECT id, title, date::text, start_time, end_time, goal, location, responsible, "
                            "       department, material, siko_text, "
                            "       bad_weather_info, planned_participants_estimate, created_at, updated_at "
-                           "FROM activities ORDER BY date DESC, start_time");
+                           "FROM activities WHERE deleted_at IS NULL ORDER BY date DESC, start_time");
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
     {
@@ -593,7 +593,7 @@ std::optional<Activity> Database::get_activity_by_id(const std::string &id)
                                  "SELECT id, title, date::text, start_time, end_time, goal, location, responsible, "
                                  "       department, material, siko_text, "
                                  "       bad_weather_info, planned_participants_estimate, created_at, updated_at "
-                                 "FROM activities WHERE id = $1",
+                                 "FROM activities WHERE id = $1 AND deleted_at IS NULL",
                                  1, nullptr, params, nullptr, nullptr, 0);
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK || PQntuples(res) == 0)
@@ -884,14 +884,90 @@ std::optional<Activity> Database::update_activity(const std::string &id, const A
 
 bool Database::delete_activity(const std::string &id)
 {
+    return soft_delete_activity(id, "");
+}
+
+bool Database::soft_delete_activity(const std::string &id, const std::string &deleted_by_user_id)
+{
+    ensure_connected();
+    const char *params[2] = {
+        id.c_str(),
+        deleted_by_user_id.empty() ? nullptr : deleted_by_user_id.c_str()};
+    PGresult *res = PQexecParams(conn_,
+                                 "UPDATE activities "
+                                 "SET deleted_at = NOW(), deleted_by = $2::uuid "
+                                 "WHERE id = $1 AND deleted_at IS NULL",
+                                 2, nullptr, params, nullptr, nullptr, 0);
+    bool ok = PQresultStatus(res) == PGRES_COMMAND_OK && PQcmdTuples(res)[0] != '0';
+    PQclear(res);
+    return ok;
+}
+
+bool Database::restore_activity(const std::string &id)
+{
     ensure_connected();
     const char *params[1] = {id.c_str()};
     PGresult *res = PQexecParams(conn_,
-                                 "DELETE FROM activities WHERE id = $1",
+                                 "UPDATE activities "
+                                 "SET deleted_at = NULL, deleted_by = NULL "
+                                 "WHERE id = $1 AND deleted_at IS NOT NULL",
                                  1, nullptr, params, nullptr, nullptr, 0);
-    bool ok = PQresultStatus(res) == PGRES_COMMAND_OK;
+    bool ok = PQresultStatus(res) == PGRES_COMMAND_OK && PQcmdTuples(res)[0] != '0';
     PQclear(res);
     return ok;
+}
+
+std::vector<DeletedActivityRecord> Database::list_deleted_activities()
+{
+    ensure_connected();
+    PGresult *res = PQexec(conn_,
+                           "SELECT a.id, a.title, a.date::text, a.start_time, a.end_time, a.goal, a.location, a.responsible, "
+                           "       a.department, a.material, a.siko_text, a.bad_weather_info, a.planned_participants_estimate, "
+                           "       a.created_at, a.updated_at, a.deleted_at, a.deleted_by::text, "
+                           "       u.display_name AS deleted_by_display_name, u.email AS deleted_by_email "
+                           "FROM activities a "
+                           "LEFT JOIN users u ON u.id = a.deleted_by "
+                           "WHERE a.deleted_at IS NOT NULL "
+                           "ORDER BY a.deleted_at DESC");
+
+    if (PQresultStatus(res) != PGRES_TUPLES_OK)
+    {
+        std::string err = PQresultErrorMessage(res);
+        PQclear(res);
+        throw std::runtime_error("list_deleted_activities: " + err);
+    }
+
+    std::vector<DeletedActivityRecord> out;
+    int n = PQntuples(res);
+    out.reserve(n);
+    for (int i = 0; i < n; ++i)
+    {
+        DeletedActivityRecord rec;
+        rec.activity = row_to_activity(res, i);
+        int deleted_at_col = PQfnumber(res, "deleted_at");
+        if (deleted_at_col >= 0 && !PQgetisnull(res, i, deleted_at_col))
+            rec.deleted_at = PQgetvalue(res, i, deleted_at_col);
+
+        int deleted_by_id_col = PQfnumber(res, "deleted_by");
+        if (deleted_by_id_col >= 0 && !PQgetisnull(res, i, deleted_by_id_col))
+            rec.deleted_by_user_id = std::string(PQgetvalue(res, i, deleted_by_id_col));
+
+        int deleted_by_name_col = PQfnumber(res, "deleted_by_display_name");
+        if (deleted_by_name_col >= 0 && !PQgetisnull(res, i, deleted_by_name_col))
+            rec.deleted_by_display_name = std::string(PQgetvalue(res, i, deleted_by_name_col));
+
+        int deleted_by_email_col = PQfnumber(res, "deleted_by_email");
+        if (deleted_by_email_col >= 0 && !PQgetisnull(res, i, deleted_by_email_col))
+            rec.deleted_by_email = std::string(PQgetvalue(res, i, deleted_by_email_col));
+
+        out.push_back(std::move(rec));
+    }
+    PQclear(res);
+
+    for (auto &rec : out)
+        attach_programs_single(rec.activity);
+
+    return out;
 }
 
 std::optional<int> Database::get_activity_midata_children_value(const std::string &activity_id)
@@ -3568,7 +3644,7 @@ std::optional<Activity> Database::get_activity_by_share_token(const std::string 
                                  "       a.bad_weather_info, a.planned_participants_estimate, a.created_at, a.updated_at "
                                  "FROM activities a "
                                  "JOIN activity_share_links s ON s.activity_id = a.id "
-                                 "WHERE s.share_token = $1",
+                                 "WHERE s.share_token = $1 AND a.deleted_at IS NULL",
                                  1, nullptr, params, nullptr, nullptr, 0);
     if (PQresultStatus(res) != PGRES_TUPLES_OK || PQntuples(res) == 0)
     {

--- a/backend/src/db.hpp
+++ b/backend/src/db.hpp
@@ -140,18 +140,18 @@ struct RolePermission
     bool can_write_own_dept;
     bool can_read_all_depts;
     bool can_write_all_depts;
-    std::string activity_read_scope;    // none|own|same_dept|all
-    std::string activity_create_scope;  // none|own_dept|all
-    std::string activity_edit_scope;    // none|own|same_dept|all
-    std::string mail_send_scope;        // none|own|same_dept|all
-    std::string mail_templates_scope;   // none|own_dept|all
-    std::string form_scope;             // none|own|same_dept|all
-    std::string form_templates_scope;   // none|own_dept|all
-    std::string event_templates_scope;  // none|own_dept|all
-    std::string event_publish_scope;    // none|own_dept|all
-    std::string user_dept_scope;        // none|own|own_dept|all
-    std::string user_role_scope;        // none|own|own_dept|all
-    std::string locations_manage_scope; // none|all
+    std::string activity_read_scope;     // none|own|same_dept|all
+    std::string activity_create_scope;   // none|own_dept|all
+    std::string activity_edit_scope;     // none|own|same_dept|all
+    std::string mail_send_scope;         // none|own|same_dept|all
+    std::string mail_templates_scope;    // none|own_dept|all
+    std::string form_scope;              // none|own|same_dept|all
+    std::string form_templates_scope;    // none|own_dept|all
+    std::string event_templates_scope;   // none|own_dept|all
+    std::string event_publish_scope;     // none|own_dept|all
+    std::string user_dept_scope;         // none|own|own_dept|all
+    std::string user_role_scope;         // none|own|own_dept|all
+    std::string locations_manage_scope;  // none|all
     std::string ideenkiste_scope;        // none|own_dept|all  (view + import)
     std::string ideenkiste_add_scope;    // none|own_dept|all  (create + edit)
     std::string ideenkiste_delete_scope; // none|own_dept|all  (delete)
@@ -200,6 +200,8 @@ public:
     bool delete_activity(const std::string &id);
     bool soft_delete_activity(const std::string &id, const std::string &deleted_by_user_id);
     bool restore_activity(const std::string &id);
+    bool permanently_delete_activity(const std::string &id);
+    int purge_deleted_activities_older_than_days(int days);
     std::vector<DeletedActivityRecord> list_deleted_activities();
     std::optional<int> get_activity_midata_children_value(const std::string &activity_id);
     bool set_activity_midata_children_value(const std::string &activity_id, int value);

--- a/backend/src/db.hpp
+++ b/backend/src/db.hpp
@@ -174,6 +174,15 @@ struct ActivityShareLink
     std::string created_at;
 };
 
+struct DeletedActivityRecord
+{
+    Activity activity;
+    std::string deleted_at;
+    std::optional<std::string> deleted_by_user_id;
+    std::optional<std::string> deleted_by_display_name;
+    std::optional<std::string> deleted_by_email;
+};
+
 class Database
 {
 public:
@@ -189,6 +198,9 @@ public:
     std::optional<Activity> create_activity(const ActivityInput &input);
     std::optional<Activity> update_activity(const std::string &id, const ActivityInput &input);
     bool delete_activity(const std::string &id);
+    bool soft_delete_activity(const std::string &id, const std::string &deleted_by_user_id);
+    bool restore_activity(const std::string &id);
+    std::vector<DeletedActivityRecord> list_deleted_activities();
     std::optional<int> get_activity_midata_children_value(const std::string &activity_id);
     bool set_activity_midata_children_value(const std::string &activity_id, int value);
     std::optional<nlohmann::json> get_activity_weather_snapshot(const std::string &activity_id);

--- a/backend/src/handlers.cpp
+++ b/backend/src/handlers.cpp
@@ -3485,7 +3485,7 @@ void handle_delete_activity(HttpRes *res, HttpReq *req, Database &db, WebSocketM
 
     try
     {
-        bool ok = db.delete_activity(id);
+        bool ok = db.soft_delete_activity(id, current_user->id);
         if (!ok)
         {
             send_json(res, 404, R"({"error":"Nicht gefunden"})");
@@ -5967,6 +5967,86 @@ static std::optional<UserRecord> require_admin(HttpRes *res, HttpReq *req, Datab
         return std::nullopt;
     }
     return user;
+}
+
+static nlohmann::json deleted_activity_to_json(const DeletedActivityRecord &r)
+{
+    nlohmann::json j;
+    j["activity"] = to_json(r.activity);
+    j["deleted_at"] = r.deleted_at;
+    j["deleted_by"] = {
+        {"id", r.deleted_by_user_id ? nlohmann::json(*r.deleted_by_user_id) : nlohmann::json(nullptr)},
+        {"display_name", r.deleted_by_display_name ? nlohmann::json(*r.deleted_by_display_name) : nlohmann::json(nullptr)},
+        {"email", r.deleted_by_email ? nlohmann::json(*r.deleted_by_email) : nlohmann::json(nullptr)}};
+    return j;
+}
+
+static std::optional<UserRecord> require_strict_admin(HttpRes *res, HttpReq *req, Database &db)
+{
+    TokenClaims claims;
+    if (!require_auth(res, req, claims))
+        return std::nullopt;
+    auto user = resolve_user(db, claims);
+    if (!user || !is_admin(*user))
+    {
+        send_json(res, 403, R"({"error":"Keine Berechtigung"})");
+        return std::nullopt;
+    }
+    return user;
+}
+
+void handle_get_admin_activity_trash(HttpRes *res, HttpReq *req, Database &db)
+{
+    if (!require_strict_admin(res, req, db))
+        return;
+
+    try
+    {
+        auto deleted = db.list_deleted_activities();
+        nlohmann::json arr = nlohmann::json::array();
+        for (const auto &entry : deleted)
+            arr.push_back(deleted_activity_to_json(entry));
+        send_json(res, 200, arr.dump());
+    }
+    catch (std::exception &e)
+    {
+        send_internal_error(res, "handler", e);
+    }
+}
+
+void handle_post_admin_activity_restore(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm)
+{
+    auto admin_user = require_strict_admin(res, req, db);
+    if (!admin_user)
+        return;
+
+    std::string id{req->getParameter(0)};
+    try
+    {
+        bool restored = db.restore_activity(id);
+        if (!restored)
+        {
+            send_json(res, 404, R"({"error":"Nicht gefunden"})");
+            return;
+        }
+
+        auto activity = db.get_activity_by_id(id);
+        if (!activity)
+        {
+            send_json(res, 500, R"({"error":"Wiederhergestellt, aber nicht lesbar"})");
+            return;
+        }
+
+        nlohmann::json msg = {{"event", "created"}, {"activity", to_json(*activity)}};
+        wm.broadcast(msg.dump());
+        cache_bump_version("activities");
+        cache_bump_version("activity");
+        send_json(res, 200, to_json(*activity).dump());
+    }
+    catch (std::exception &e)
+    {
+        send_internal_error(res, "handler", e);
+    }
 }
 
 void handle_get_admin_midata_status(HttpRes *res, HttpReq *req, Database &db)

--- a/backend/src/handlers.cpp
+++ b/backend/src/handlers.cpp
@@ -6049,6 +6049,34 @@ void handle_post_admin_activity_restore(HttpRes *res, HttpReq *req, Database &db
     }
 }
 
+void handle_delete_admin_activity_trash(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm)
+{
+    auto admin_user = require_strict_admin(res, req, db);
+    if (!admin_user)
+        return;
+
+    std::string id{req->getParameter(0)};
+    try
+    {
+        bool deleted = db.permanently_delete_activity(id);
+        if (!deleted)
+        {
+            send_json(res, 404, R"({"error":"Nicht gefunden"})");
+            return;
+        }
+
+        nlohmann::json msg = {{"event", "deleted"}, {"id", id}};
+        wm.broadcast(msg.dump());
+        cache_bump_version("activities");
+        cache_bump_version("activity");
+        send_json(res, 200, R"({"ok":true})");
+    }
+    catch (std::exception &e)
+    {
+        send_internal_error(res, "handler", e);
+    }
+}
+
 void handle_get_admin_midata_status(HttpRes *res, HttpReq *req, Database &db)
 {
     if (!require_admin(res, req, db))
@@ -7604,10 +7632,15 @@ void handle_get_shared_activity(HttpRes *res, HttpReq *req, Database &db)
 
 // ── Ideenkiste ───────────────────────────────────────────────────────────────
 
-enum class IdeenkisteOp { View, Add, Delete };
+enum class IdeenkisteOp
+{
+    View,
+    Add,
+    Delete
+};
 
 static std::optional<std::string> ideenkiste_check(HttpRes *res, HttpReq *req, Database &db,
-                                                    UserRecord &out_user, IdeenkisteOp op)
+                                                   UserRecord &out_user, IdeenkisteOp op)
 {
     TokenClaims claims;
     if (!require_auth(res, req, claims))
@@ -7628,9 +7661,15 @@ static std::optional<std::string> ideenkiste_check(HttpRes *res, HttpReq *req, D
     {
         switch (op)
         {
-        case IdeenkisteOp::View:   scope = perm->ideenkiste_scope; break;
-        case IdeenkisteOp::Add:    scope = perm->ideenkiste_add_scope; break;
-        case IdeenkisteOp::Delete: scope = perm->ideenkiste_delete_scope; break;
+        case IdeenkisteOp::View:
+            scope = perm->ideenkiste_scope;
+            break;
+        case IdeenkisteOp::Add:
+            scope = perm->ideenkiste_add_scope;
+            break;
+        case IdeenkisteOp::Delete:
+            scope = perm->ideenkiste_delete_scope;
+            break;
         }
     }
     else
@@ -7699,7 +7738,7 @@ void handle_post_ideenkiste(HttpRes *res, HttpReq *req, Database &db)
         return;
     res->onAborted([]() {});
     res->onData([res, &db, user_dept = user.department, scope = *scope](std::string_view body, bool last)
-    {
+                {
         if (!last) return;
         try
         {
@@ -7728,8 +7767,7 @@ void handle_post_ideenkiste(HttpRes *res, HttpReq *req, Database &db)
         catch (std::exception &e)
         {
             send_internal_error(res, "handler", e);
-        }
-    });
+        } });
 }
 
 void handle_put_ideenkiste(HttpRes *res, HttpReq *req, Database &db)
@@ -7741,7 +7779,7 @@ void handle_put_ideenkiste(HttpRes *res, HttpReq *req, Database &db)
     std::string id{req->getParameter(0)};
     res->onAborted([]() {});
     res->onData([res, &db, id, user_dept = user.department, scope = *scope](std::string_view body, bool last)
-    {
+                {
         if (!last) return;
         try
         {
@@ -7776,8 +7814,7 @@ void handle_put_ideenkiste(HttpRes *res, HttpReq *req, Database &db)
         catch (std::exception &e)
         {
             send_internal_error(res, "handler", e);
-        }
-    });
+        } });
 }
 
 void handle_delete_ideenkiste(HttpRes *res, HttpReq *req, Database &db)

--- a/backend/src/handlers.hpp
+++ b/backend/src/handlers.hpp
@@ -40,6 +40,7 @@ void handle_patch_activity(HttpRes *res, HttpReq *req, Database &db, WebSocketMa
 void handle_delete_activity(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
 void handle_get_admin_activity_trash(HttpRes *res, HttpReq *req, Database &db);
 void handle_post_admin_activity_restore(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
+void handle_delete_admin_activity_trash(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
 
 // Predefined locations
 void handle_get_locations(HttpRes *res, HttpReq *req, Database &db);

--- a/backend/src/handlers.hpp
+++ b/backend/src/handlers.hpp
@@ -38,6 +38,8 @@ void handle_get_activity_expected_weather(HttpRes *res, HttpReq *req, Database &
 void handle_post_activity(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
 void handle_patch_activity(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
 void handle_delete_activity(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
+void handle_get_admin_activity_trash(HttpRes *res, HttpReq *req, Database &db);
+void handle_post_admin_activity_restore(HttpRes *res, HttpReq *req, Database &db, WebSocketManager &wm);
 
 // Predefined locations
 void handle_get_locations(HttpRes *res, HttpReq *req, Database &db);

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -8,7 +8,72 @@
 #include <string>
 #include <cstdio>
 #include <vector>
+#include <thread>
+#include <algorithm>
+#include <chrono>
+#include <type_traits>
 #include <curl/curl.h>
+
+namespace
+{
+     constexpr int kDeletedActivityRetentionDays = 90;
+     constexpr auto kDeletedActivityPurgeInterval = std::chrono::hours(24);
+     constexpr auto kDeletedActivityPurgeStopCheckInterval = std::chrono::minutes(1);
+
+     void run_deleted_activity_purge_once(const std::string &conn_str)
+     {
+          Database job_db(conn_str);
+          const int deleted_count = job_db.purge_deleted_activities_older_than_days(kDeletedActivityRetentionDays);
+          if (deleted_count > 0)
+               std::printf("[jobs] purged %d deleted activit%s older than %d days\n",
+                           deleted_count,
+                           deleted_count == 1 ? "y" : "ies",
+                           kDeletedActivityRetentionDays);
+     }
+
+     void wait_for_next_purge(std::stop_token stop_token)
+     {
+          using purge_duration = std::common_type_t<decltype(kDeletedActivityPurgeInterval), decltype(kDeletedActivityPurgeStopCheckInterval)>;
+
+          auto remaining = purge_duration(kDeletedActivityPurgeInterval);
+          while (remaining > purge_duration::zero() && !stop_token.stop_requested())
+          {
+               const auto sleep_for = std::min(remaining, purge_duration(kDeletedActivityPurgeStopCheckInterval));
+               std::this_thread::sleep_for(sleep_for);
+               remaining -= sleep_for;
+          }
+     }
+
+     std::jthread start_deleted_activity_purge_job(const std::string &conn_str)
+     {
+          return std::jthread([conn_str](std::stop_token stop_token)
+                              {
+                                   try
+                                   {
+                                        run_deleted_activity_purge_once(conn_str);
+                                   }
+                                   catch (const std::exception &e)
+                                   {
+                                        std::fprintf(stderr, "[jobs] failed to purge deleted activities on startup: %s\n", e.what());
+                                   }
+
+                                   while (!stop_token.stop_requested())
+                                   {
+                                        wait_for_next_purge(stop_token);
+                                        if (stop_token.stop_requested())
+                                             break;
+
+                                        try
+                                        {
+                                             run_deleted_activity_purge_once(conn_str);
+                                        }
+                                        catch (const std::exception &e)
+                                        {
+                                             std::fprintf(stderr, "[jobs] failed to purge deleted activities: %s\n", e.what());
+                                        }
+                                   } });
+     }
+}
 
 static std::string url_decode_component(std::string_view src)
 {
@@ -104,6 +169,8 @@ int main()
           setenv("AZURE_CLIENT_ID", azure_client->c_str(), 1);
      if (azure_secret && !azure_secret->empty())
           setenv("AZURE_CLIENT_SECRET", azure_secret->c_str(), 1);
+
+     auto deleted_activity_purge_job = start_deleted_activity_purge_job(conn_str);
 
      WebSocketManager wm(db);
 
@@ -205,6 +272,8 @@ int main()
               { handle_get_admin_activity_trash(res, req, db); })
          .post("/admin/activities/:id/restore", [&](auto *res, auto *req)
                { handle_post_admin_activity_restore(res, req, db, wm); })
+         .del("/admin/activities/:id/trash", [&](auto *res, auto *req)
+              { handle_delete_admin_activity_trash(res, req, db, wm); })
 
          // Static data
          .get("/departments", [&](auto *res, auto *req)

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -201,6 +201,10 @@ int main()
               { handle_get_role_dept_access(res, req, db); })
          .put("/admin/role-dept-access", [&](auto *res, auto *req)
               { handle_put_role_dept_access(res, req, db); })
+         .get("/admin/activities/trash", [&](auto *res, auto *req)
+              { handle_get_admin_activity_trash(res, req, db); })
+         .post("/admin/activities/:id/restore", [&](auto *res, auto *req)
+               { handle_post_admin_activity_restore(res, req, db, wm); })
 
          // Static data
          .get("/departments", [&](auto *res, auto *req)

--- a/db/init.sql
+++ b/db/init.sql
@@ -95,9 +95,14 @@ CREATE TABLE IF NOT EXISTS activities (
     weather_location TEXT,
     weather_snapshot JSONB,
     weather_recorded_at TIMESTAMPTZ,
+    deleted_at       TIMESTAMPTZ,
+    deleted_by       UUID,
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE activities ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+ALTER TABLE activities ADD COLUMN IF NOT EXISTS deleted_by UUID;
 
 CREATE TABLE IF NOT EXISTS programs (
     id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -122,6 +127,7 @@ CREATE TRIGGER trg_activities_updated_at
     FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
 
 CREATE INDEX IF NOT EXISTS idx_activities_date ON activities (date DESC, start_time);
+CREATE INDEX IF NOT EXISTS idx_activities_deleted_at ON activities (deleted_at);
 CREATE INDEX IF NOT EXISTS idx_programs_activity_id ON programs (activity_id);
 
 CREATE TABLE IF NOT EXISTS ideenkiste (
@@ -167,6 +173,20 @@ CREATE TRIGGER trg_users_updated_at
     FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
 
 CREATE INDEX IF NOT EXISTS idx_users_microsoft_oid ON users (microsoft_oid);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'activities_deleted_by_fkey'
+    ) THEN
+        ALTER TABLE activities
+            ADD CONSTRAINT activities_deleted_by_fkey
+            FOREIGN KEY (deleted_by) REFERENCES users(id) ON DELETE SET NULL;
+    END IF;
+END;
+$$;
 
 -- Mail templates (one per department)
 CREATE TABLE IF NOT EXISTS mail_templates (

--- a/frontend/src/composables/useActivities.ts
+++ b/frontend/src/composables/useActivities.ts
@@ -3,6 +3,7 @@ import type {
 	Activity,
 	ActivityInput,
 	Attachment,
+	DeletedActivityRecord,
 	Department,
 	WsEvent,
 } from '../types';
@@ -172,6 +173,36 @@ export function useActivities() {
 		}
 	}
 
+	async function fetchDeletedActivities(): Promise<DeletedActivityRecord[]> {
+		error.value = null;
+		try {
+			const res = await apiFetch(`${BASE}/admin/activities/trash`);
+			if (!res.ok) throw new Error(await res.text());
+			return (await res.json()) as DeletedActivityRecord[];
+		} catch (e) {
+			error.value = formatApiError(e);
+			return [];
+		}
+	}
+
+	async function restoreActivity(id: string): Promise<Activity | null> {
+		error.value = null;
+		try {
+			const res = await apiFetch(`${BASE}/admin/activities/${id}/restore`, {
+				method: 'POST',
+			});
+			if (!res.ok) throw new Error(await res.text());
+			const restored = (await res.json()) as Activity;
+			if (!activities.value.find((a) => a.id === restored.id)) {
+				activities.value.unshift(restored);
+			}
+			return restored;
+		} catch (e) {
+			error.value = formatApiError(e);
+			return null;
+		}
+	}
+
 	// ---- Predefined locations ------------------------------------------------
 
 	async function fetchLocations(): Promise<void> {
@@ -267,6 +298,8 @@ export function useActivities() {
 		createActivity,
 		updateActivity,
 		deleteActivity,
+		fetchDeletedActivities,
+		restoreActivity,
 		fetchAttachments,
 		uploadAttachment,
 		deleteAttachment,

--- a/frontend/src/composables/useActivities.ts
+++ b/frontend/src/composables/useActivities.ts
@@ -203,6 +203,23 @@ export function useActivities() {
 		}
 	}
 
+	async function deleteDeletedActivity(id: string): Promise<boolean> {
+		error.value = null;
+		try {
+			const res = await apiFetch(`${BASE}/admin/activities/${id}/trash`, {
+				method: 'DELETE',
+			});
+			if (!res.ok) throw new Error(await res.text());
+			activities.value = activities.value.filter(
+				(activity) => activity.id !== id,
+			);
+			return true;
+		} catch (e) {
+			error.value = formatApiError(e);
+			return false;
+		}
+	}
+
 	// ---- Predefined locations ------------------------------------------------
 
 	async function fetchLocations(): Promise<void> {
@@ -300,6 +317,7 @@ export function useActivities() {
 		deleteActivity,
 		fetchDeletedActivities,
 		restoreActivity,
+		deleteDeletedActivity,
 		fetchAttachments,
 		uploadAttachment,
 		deleteAttachment,

--- a/frontend/src/pages/AdminPage.vue
+++ b/frontend/src/pages/AdminPage.vue
@@ -18,7 +18,7 @@ import type { User, Department, UserRole, DeletedActivityRecord } from '../types
 
 const router = useRouter()
 const { departments: deptRecords, roles: roleRecords, fetchDepartments, fetchRoles, myPermissions, fetchMyPermissions, canManageUsers, canManageSystem, canManageLocations } = usePermissions()
-const { fetchDeletedActivities, restoreActivity } = useActivities()
+const { fetchDeletedActivities, restoreActivity, deleteDeletedActivity } = useActivities()
 
 const DEPARTMENTS = computed(() => deptRecords.value.map(d => d.name))
 const orderedRoles = computed(() => [...roleRecords.value].sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name, 'de')))
@@ -55,6 +55,7 @@ const deletedActivities = ref<DeletedActivityRecord[]>([])
 const trashLoading = ref(false)
 const trashError = ref<string | null>(null)
 const restoringActivityId = ref<string | null>(null)
+const deletingActivityId = ref<string | null>(null)
 
 const filterDept = ref<Department | 'Alle'>('Alle')
 
@@ -87,6 +88,12 @@ function formatDateTime(iso: string) {
   return new Date(iso).toLocaleString('de-DE')
 }
 
+function formatAutoDeleteDate(iso: string) {
+  const date = new Date(iso)
+  date.setDate(date.getDate() + 90)
+  return date.toLocaleString('de-DE')
+}
+
 async function loadDeletedActivities() {
   if (!canSeeTrashTab.value) return
   trashLoading.value = true
@@ -112,6 +119,25 @@ async function restoreDeletedActivity(entry: DeletedActivityRecord) {
     trashError.value = String(e)
   } finally {
     restoringActivityId.value = null
+  }
+}
+
+async function permanentlyDeleteActivity(entry: DeletedActivityRecord) {
+  if (!canSeeTrashTab.value) return
+  if (!window.confirm(`Aktivität "${entry.activity.title}" endgültig löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) {
+    return
+  }
+
+  deletingActivityId.value = entry.activity.id
+  trashError.value = null
+  try {
+    const deleted = await deleteDeletedActivity(entry.activity.id)
+    if (!deleted) throw new Error('Endgültiges Löschen fehlgeschlagen')
+    deletedActivities.value = deletedActivities.value.filter((item) => item.activity.id !== entry.activity.id)
+  } catch (e) {
+    trashError.value = String(e)
+  } finally {
+    deletingActivityId.value = null
   }
 }
 
@@ -389,6 +415,7 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
     <div class="tab-header">
       <div class="tab-header-left">
         <h2 class="trash-title">Gelöschte Aktivitäten</h2>
+        <p class="trash-note">Einträge im Papierkorb werden nach 90 Tagen automatisch endgültig gelöscht.</p>
       </div>
       <span class="user-count">{{ deletedActivities.length }} Einträge</span>
     </div>
@@ -402,6 +429,7 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
             <th>Titel</th>
             <th>Datum</th>
             <th>Gelöscht am</th>
+            <th>Auto-Löschung</th>
             <th>Gelöscht von</th>
             <th></th>
           </tr>
@@ -411,19 +439,29 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
             <td class="td-name" data-label="Titel">{{ entry.activity.title }}</td>
             <td data-label="Datum">{{ entry.activity.date }}</td>
             <td data-label="Gelöscht am">{{ formatDateTime(entry.deleted_at) }}</td>
+            <td data-label="Auto-Löschung">{{ formatAutoDeleteDate(entry.deleted_at) }}</td>
             <td class="td-email" data-label="Gelöscht von">{{ entry.deleted_by.display_name || entry.deleted_by.email || 'Unbekannt' }}</td>
             <td data-label="Aktionen">
-              <button
-                class="btn-primary btn-restore"
-                :disabled="restoringActivityId === entry.activity.id"
-                @click="restoreDeletedActivity(entry)"
-              >
-                {{ restoringActivityId === entry.activity.id ? 'Wird wiederhergestellt...' : 'Wiederherstellen' }}
-              </button>
+              <div class="trash-actions">
+                <button
+                  class="btn-primary btn-restore"
+                  :disabled="restoringActivityId === entry.activity.id || deletingActivityId === entry.activity.id"
+                  @click="restoreDeletedActivity(entry)"
+                >
+                  {{ restoringActivityId === entry.activity.id ? 'Wird wiederhergestellt...' : 'Wiederherstellen' }}
+                </button>
+                <button
+                  class="btn-danger btn-delete-forever"
+                  :disabled="deletingActivityId === entry.activity.id || restoringActivityId === entry.activity.id"
+                  @click="permanentlyDeleteActivity(entry)"
+                >
+                  {{ deletingActivityId === entry.activity.id ? 'Wird gelöscht...' : 'Endgültig löschen' }}
+                </button>
+              </div>
             </td>
           </tr>
           <tr v-if="deletedActivities.length === 0">
-            <td colspan="5" class="td-empty">Keine gelöschten Aktivitäten.</td>
+            <td colspan="6" class="td-empty">Keine gelöschten Aktivitäten.</td>
           </tr>
         </tbody>
       </table>
@@ -818,9 +856,30 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
   color: var(--text-primary);
 }
 
+.trash-note {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.trash-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  min-width: 180px;
+}
+
 .btn-restore {
   padding: 6px 12px;
   font-size: 0.82rem;
+  width: 100%;
+}
+
+.btn-delete-forever {
+  padding: 6px 12px;
+  font-size: 0.82rem;
+  width: 100%;
 }
 
 @media (max-width: 599px) {
@@ -905,6 +964,9 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
   .item-actions {
     justify-content: flex-start;
     gap: 8px;
+  }
+  .trash-actions {
+    min-width: 0;
   }
   .btn-edit,
   .btn-delete {

--- a/frontend/src/pages/AdminPage.vue
+++ b/frontend/src/pages/AdminPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
-import { Lock, MapPin, Users } from 'lucide-vue-next'
+import { Lock, MapPin, Trash2, Users } from 'lucide-vue-next'
 import { user as currentUser } from '../composables/useAuth'
 import { apiFetch } from '../composables/useApi'
 import ErrorAlert from '../components/ErrorAlert.vue'
@@ -13,10 +13,12 @@ import DepartmentBadge from '../components/DepartmentBadge.vue'
 import BadgeSelect from '../components/BadgeSelect.vue'
 import { useRouter } from 'vue-router'
 import { usePermissions } from '../composables/usePermissions'
-import type { User, Department, UserRole } from '../types'
+import { useActivities } from '../composables/useActivities'
+import type { User, Department, UserRole, DeletedActivityRecord } from '../types'
 
 const router = useRouter()
 const { departments: deptRecords, roles: roleRecords, fetchDepartments, fetchRoles, myPermissions, fetchMyPermissions, canManageUsers, canManageSystem, canManageLocations } = usePermissions()
+const { fetchDeletedActivities, restoreActivity } = useActivities()
 
 const DEPARTMENTS = computed(() => deptRecords.value.map(d => d.name))
 const orderedRoles = computed(() => [...roleRecords.value].sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name, 'de')))
@@ -33,9 +35,10 @@ const canEditRoles = computed(() => {
 })
 const canSeePermissionsTab = computed(() => canManageSystem())
 const canSeeLocationsTab = computed(() => canManageLocations())
+const canSeeTrashTab = computed(() => currentUser.value?.role === 'admin')
 
 // ── Tab management ──────────────────────────────────────────────────────────
-const activeTab = ref<'users' | 'permissions' | 'locations' | 'system'>('users')
+const activeTab = ref<'users' | 'permissions' | 'locations' | 'trash' | 'system'>('users')
 
 // ── User management state ───────────────────────────────────────────────────
 const users = ref<User[]>([])
@@ -47,6 +50,11 @@ const editForm = ref({ display_name: '', department: '' as Department | '', role
 const saving = ref(false)
 const saveError = ref<string | null>(null)
 const deleteTarget = ref<User | null>(null)
+
+const deletedActivities = ref<DeletedActivityRecord[]>([])
+const trashLoading = ref(false)
+const trashError = ref<string | null>(null)
+const restoringActivityId = ref<string | null>(null)
 
 const filterDept = ref<Department | 'Alle'>('Alle')
 
@@ -69,8 +77,43 @@ onMounted(async () => {
   if (canEditRoles.value || canSeePermissionsTab.value) {
     tasks.push(fetchRoles())
   }
+  if (canSeeTrashTab.value) {
+    tasks.push(loadDeletedActivities())
+  }
   await Promise.all(tasks)
 })
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString('de-DE')
+}
+
+async function loadDeletedActivities() {
+  if (!canSeeTrashTab.value) return
+  trashLoading.value = true
+  trashError.value = null
+  try {
+    deletedActivities.value = await fetchDeletedActivities()
+  } catch (e) {
+    trashError.value = String(e)
+  } finally {
+    trashLoading.value = false
+  }
+}
+
+async function restoreDeletedActivity(entry: DeletedActivityRecord) {
+  if (!canSeeTrashTab.value) return
+  restoringActivityId.value = entry.activity.id
+  trashError.value = null
+  try {
+    const restored = await restoreActivity(entry.activity.id)
+    if (!restored) throw new Error('Wiederherstellung fehlgeschlagen')
+    deletedActivities.value = deletedActivities.value.filter((item) => item.activity.id !== entry.activity.id)
+  } catch (e) {
+    trashError.value = String(e)
+  } finally {
+    restoringActivityId.value = null
+  }
+}
 
 async function fetchUsers() {
   loading.value = true
@@ -234,6 +277,15 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
       Orte
     </button>
     <button
+      v-if="canSeeTrashTab"
+      class="tab-btn"
+      :class="{ 'tab-btn--active': activeTab === 'trash' }"
+      @click="activeTab = 'trash'; void loadDeletedActivities()"
+    >
+      <Trash2 :size="16" aria-hidden="true" />
+      Papierkorb
+    </button>
+    <button
       v-if="canSeePermissionsTab"
       class="tab-btn"
       :class="{ 'tab-btn--active': activeTab === 'system' }"
@@ -331,6 +383,51 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
   <!-- Tab: Orte (locations_manage_scope = all) -->
   <main v-else-if="activeTab === 'locations' && canSeeLocationsTab" class="main">
     <LocationManager />
+  </main>
+
+  <main v-else-if="activeTab === 'trash' && canSeeTrashTab" class="main">
+    <div class="tab-header">
+      <div class="tab-header-left">
+        <h2 class="trash-title">Gelöschte Aktivitäten</h2>
+      </div>
+      <span class="user-count">{{ deletedActivities.length }} Einträge</span>
+    </div>
+
+    <div v-if="trashLoading" class="loading">Lade Papierkorb...</div>
+    <div v-else-if="trashError" class="error-msg"><ErrorAlert :error="trashError" /></div>
+    <div v-else class="table-wrap">
+      <table class="users-table">
+        <thead>
+          <tr>
+            <th>Titel</th>
+            <th>Datum</th>
+            <th>Gelöscht am</th>
+            <th>Gelöscht von</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="entry in deletedActivities" :key="entry.activity.id">
+            <td class="td-name" data-label="Titel">{{ entry.activity.title }}</td>
+            <td data-label="Datum">{{ entry.activity.date }}</td>
+            <td data-label="Gelöscht am">{{ formatDateTime(entry.deleted_at) }}</td>
+            <td class="td-email" data-label="Gelöscht von">{{ entry.deleted_by.display_name || entry.deleted_by.email || 'Unbekannt' }}</td>
+            <td data-label="Aktionen">
+              <button
+                class="btn-primary btn-restore"
+                :disabled="restoringActivityId === entry.activity.id"
+                @click="restoreDeletedActivity(entry)"
+              >
+                {{ restoringActivityId === entry.activity.id ? 'Wird wiederhergestellt...' : 'Wiederherstellen' }}
+              </button>
+            </td>
+          </tr>
+          <tr v-if="deletedActivities.length === 0">
+            <td colspan="5" class="td-empty">Keine gelöschten Aktivitäten.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </main>
 
   <main v-else-if="activeTab === 'system' && canSeePermissionsTab" class="main">
@@ -713,6 +810,18 @@ const roleItems = computed(() => assignableRoles.value.map(name => ({ value: nam
 }
 .btn-primary:hover:not(:disabled) { background: var(--btn-primary-bg-hover); }
 .btn-primary:disabled { opacity: 0.6; cursor: default; }
+
+.trash-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.btn-restore {
+  padding: 6px 12px;
+  font-size: 0.82rem;
+}
 
 @media (max-width: 599px) {
   .header {

--- a/frontend/src/pages/DetailPage.vue
+++ b/frontend/src/pages/DetailPage.vue
@@ -2638,7 +2638,7 @@ async function doSave(opts: { skipFuzzyCheck?: boolean } = {}) {
 
 // ---- Delete ----------------------------------------------------------------
 async function doDelete() {
-	if (!confirm(`Aktivität "${activity.value?.title || id}" wirklich löschen?`))
+	if (!confirm(`Aktivität "${activity.value?.title || id}" in den Papierkorb verschieben?`))
 		return;
 	await deleteActivity(id);
 	router.push('/');
@@ -3782,7 +3782,7 @@ function copyShareLink() {
 					v-if="canDelete"
 					@click="doDelete"
 				>
-					Löschen
+					In Papierkorb
 				</button>
 				<button type="button" class="btn-secondary" @click="cancelEdit">
 					Abbrechen

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -41,6 +41,16 @@ export interface Activity {
 	programs: Program[];
 }
 
+export interface DeletedActivityRecord {
+	activity: Activity;
+	deleted_at: string;
+	deleted_by: {
+		id: string | null;
+		display_name: string | null;
+		email: string | null;
+	};
+}
+
 export interface ActivityInput {
 	title: string;
 	date: string;


### PR DESCRIPTION
Umgesetzte Funktionen:

- Aktivitaeten werden bei DELETE nicht mehr hart geloescht, sondern per Soft-Delete in den Papierkorb verschoben (deleted_at/deleted_by).

- Normale Aktivitaets-Endpoints und Share-Views liefern nur nicht geloeschte Aktivitaeten.

- Neue Admin-API zum Anzeigen geloeschter Aktivitaeten: GET /api/admin/activities/trash.

- Neue Admin-API zum Wiederherstellen: POST /api/admin/activities/:id/restore.

- Zugriff auf Papierkorb/Restore ist strikt auf Rolle admin begrenzt.

- Frontend: Admin-Seite hat neuen Papierkorb-Tab mit Liste, Loeschinfos und Wiederherstellen-Button.

- Frontend: Loesch-UX in Detailansicht auf 'In Papierkorb' umbenannt.

- DB-Schema (init.sql) erweitert: deleted_at, deleted_by, FK, Index und idempotente ALTER/Constraint-Absicherung.

- Enthalten sind alle aktuellen Workspace-Aenderungen (inkl. Makefile).

Getestet (bereits ausgefuehrt):

- Frontend Unit Tests: make test-frontend (43/43 bestanden).

- Backend Unit Tests: make test-backend (64/64 bestanden).

Was zusaetzlich getestet werden soll (manuell/Integration):

1) Aktivitaet loeschen -> Eintrag erscheint im Admin-Papierkorb.

2) Nicht-Admin sieht keinen Papierkorb-Tab und bekommt 403 auf Trash/Restore-API.

3) Admin kann aus Papierkorb wiederherstellen -> Aktivitaet ist wieder in Listen/Detail sichtbar.

4) Share-Link auf geloeschte Aktivitaet liefert keinen Zugriff; nach Restore wieder verfuegbar.

5) DB-Migration auf bestehender Instanz: init.sql laeuft idempotent ohne Fehler.