### PR TITLE
fix: ensure admin users always can manage materials and locations tabs

### DIFF
--- a/backend/src/handlers/admin.cpp
+++ b/backend/src/handlers/admin.cpp
@@ -25,6 +25,7 @@ static nlohmann::json role_perm_to_json(const RolePermission &rp)
         {"user_dept_scope", rp.user_dept_scope},
         {"user_role_scope", rp.user_role_scope},
         {"locations_manage_scope", rp.locations_manage_scope},
+        {"materials_manage_scope", rp.materials_manage_scope},
         {"ideenkiste_scope", rp.ideenkiste_scope},
         {"ideenkiste_add_scope", rp.ideenkiste_add_scope},
         {"ideenkiste_delete_scope", rp.ideenkiste_delete_scope}};

--- a/frontend/src/composables/usePermissions.ts
+++ b/frontend/src/composables/usePermissions.ts
@@ -266,11 +266,7 @@ function canForms(
 		activity.department === userDept
 	)
 		return true;
-	if (
-		p.form_scope === 'own' &&
-		userId &&
-		activity.responsible.includes(userId)
-	)
+	if (p.form_scope === 'own' && userId && activity.responsible.includes(userId))
 		return true;
 	return false;
 }
@@ -307,11 +303,19 @@ function writableDepts(userDept: string | null | undefined): string[] {
 }
 
 function canManageLocations(): boolean {
-	return myPermissions.value?.locations_manage_scope === 'all';
+	const p = myPermissions.value;
+	if (!p) return false;
+	// Admin users (user_role_scope === 'all') always have full access
+	if (p.user_role_scope === 'all') return true;
+	return p.locations_manage_scope === 'all';
 }
 
 function canManageMaterials(): boolean {
-	return myPermissions.value?.materials_manage_scope === 'all';
+	const p = myPermissions.value;
+	if (!p) return false;
+	// Admin users (user_role_scope === 'all') always have full access
+	if (p.user_role_scope === 'all') return true;
+	return p.materials_manage_scope === 'all';
 }
 
 function canIdeenkiste(): boolean {
@@ -353,22 +357,18 @@ async function updateLocation(
 	id: string,
 	name: string,
 ): Promise<LocationRecord> {
-	const res = await apiFetch(
-		`/api/admin/locations/${encodeURIComponent(id)}`,
-		{
-			method: 'PATCH',
-			body: JSON.stringify({ name }),
-		},
-	);
+	const res = await apiFetch(`/api/admin/locations/${encodeURIComponent(id)}`, {
+		method: 'PATCH',
+		body: JSON.stringify({ name }),
+	});
 	if (!res.ok) throw new Error(await res.text());
 	return await res.json();
 }
 
 async function deleteLocation(id: string): Promise<void> {
-	const res = await apiFetch(
-		`/api/admin/locations/${encodeURIComponent(id)}`,
-		{ method: 'DELETE' },
-	);
+	const res = await apiFetch(`/api/admin/locations/${encodeURIComponent(id)}`, {
+		method: 'DELETE',
+	});
 	if (!res.ok) throw new Error(await res.text());
 }
 
@@ -389,7 +389,10 @@ async function createMaterial(name: string): Promise<MaterialNameRecord> {
 	return await res.json();
 }
 
-async function updateMaterial(id: string, name: string): Promise<MaterialNameRecord> {
+async function updateMaterial(
+	id: string,
+	name: string,
+): Promise<MaterialNameRecord> {
 	const res = await apiFetch(`/api/admin/materials/${encodeURIComponent(id)}`, {
 		method: 'PATCH',
 		body: JSON.stringify({ name }),


### PR DESCRIPTION
- Add admin bypass check (user_role_scope === 'all') to canManageMaterials() and canManageLocations() in usePermissions.ts so admins always see these tabs
- Fix role_perm_to_json serialization bug in backend that could cause permissions like materials_manage_scope to be lost due to pg_array type casting issues