### PR TITLE
fix: preserve numbered list styling in rich editor view mode

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1988,6 +1988,22 @@ video {
 	overflow-wrap: anywhere;
 }
 
+/* Fix list indentation in program description (view mode) */
+/* Note: <ol> elements are intentionally excluded so numbered lists display correctly */
+.program-desc > ul,
+.program-desc > div > ul {
+	list-style-type: disc;
+	list-style-position: outside;
+	padding-left: 24px;
+}
+
+.program-desc > ol,
+.program-desc > div > ol {
+	list-style-type: decimal;
+	list-style-position: outside;
+	padding-left: 24px;
+}
+
 .program-resp {
 	font-size: 0.82rem;
 	color: var(--text-muted);


### PR DESCRIPTION
Remove ol from disc list-style rule in .program-desc CSS so that ordered lists display as numbers (1, 2, 3...) instead of bullet points.